### PR TITLE
add missing links to Ecosystem

### DIFF
--- a/_includes/ecosystem.html
+++ b/_includes/ecosystem.html
@@ -125,14 +125,14 @@
                   Julia is designed from the ground up to be very good at numerical and scientific computing.
                   This can be seen in the abundance of scientific tooling written in Julia, such as the state-of-the-art
                   differential equations ecosystem
-                  <a href = "">(DiffEq)</a>, optimization tools (
-                  <a href = "">JuMP</a> and
-                  <a href = "">Optim </a>), iterative linear solvers
-                  <a href = "">(IterativeSolvers)</a> and many more, that can drive all your simulations.
+                  <a href = "http://juliadiffeq.org/">(DiffEq)</a>, optimization tools (
+                  <a href = "https://github.com/JuliaOpt/JuMP.jl">JuMP</a> and
+                  <a href = "http://julianlsolvers.github.io/Optim.jl/stable/">Optim</a>), iterative linear solvers
+                  <a href = "http://juliamath.github.io/IterativeSolvers.jl/latest/">(IterativeSolvers)</a> and many more, that can drive all your simulations.
                   </p>
                   Julia also offers a number of domain-specific ecosystems, such as in biology
                   <a href = "https://github.com/BioJulia"> (BioJulia)</a>, operations research
-                  <a href = "https://www.juliaopt.org"> (JuliaOpt) </a></li>, quantum computing
+                  <a href = "https://www.juliaopt.org"> (JuliaOpt)</a></li>, quantum computing
                   <a href = "https://github.com/qojulia/QuantumOptics.jl"> (QuantumOptics)</a>, nonlinear dynamics
                   <a href = "https://github.com/JuliaDynamics"> (JuliaDynamics)</a>, quantitative economics
                   <a href = "https://github.com/QuantEcon">(QuantEcon)</a>, astronomy


### PR DESCRIPTION
There were no links thus when clicking on e.g. DiffEq you were brought back to the julia homepage.