### PR TITLE
Remove whitespace between navbar and alerts

### DIFF
--- a/_includes/alerts.html
+++ b/_includes/alerts.html
@@ -1,6 +1,6 @@
 <!-- alerts -->
 <div class="container-fluid" id="top-alert">
-  <div class="alert alert-dark" role="alert">
+  <div class="alert alert-dark mb-0" role="alert">
     <p class="text-center">
       <a href="http://juliacon.org">JuliaCon</a> will be <a href="http://bit.ly/JuliaCon2018LIVE">streamed live</a> from Aug 7 to Aug 10.
     </p>


### PR DESCRIPTION
If you hover over a button in the navbar, there is a white margin between it and the alert at the top