### PR TITLE
Fix stretching of ML gif in ecosystems

### DIFF
--- a/_includes/ecosystem.html
+++ b/_includes/ecosystem.html
@@ -87,7 +87,7 @@
           <h3 class="tab-title">Machine Learning</h3>
           <div class="row">
             <div class="col-lg-12">
-              <img src="images/cartpole.gif" class="pb-2 ecosystem-image" style="width: 400px; height: 350px" />
+              <img src="images/cartpole.gif" class="pb-2 ecosystem-image" style="width: 400px; height: 267px" />
               <div class="container">
                 <h4>
                   Scalable Machine Learning


### PR DESCRIPTION
This is the actual height of the newly compressed gif. Note that I edited this file on github, but this should work and fix it