### PR TITLE
corrected wrong names in benchmark explanation

### DIFF
--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -41,7 +41,7 @@ Python, and Octave use <a href="https://github.com/xianyi/OpenBLAS">OpenBLAS</a>
 matrix operations; Mathematica uses Intel(R) MKL.  The Python
 environment is <a href="https://anaconda.org/anaconda/python">Anaconda
 Python</a> v3.6.3.  The Python implementations of
-<tt>rand_mat_stat</tt> and <tt>rand_mat_mul</tt> use <a href="http://www.numpy.org/">NumPy</a> v1.13.1 and OpenBLAS v0.2.19
+<tt>matrix_statistics</tt> and <tt>matrix_multiply</tt> use <a href="http://www.numpy.org/">NumPy</a> v1.13.1 and OpenBLAS v0.2.19
 functions; the rest are pure Python implementations. Raw benchmark
 numbers in CSV format are available <a href="/benchmarks/benchmarks.csv">here</a> and the
 benchmark source code for each language can be found in the <tt>perf.</tt>


### PR DESCRIPTION
names were changed in JuliaLang/Microbenchmarks@d9236c02b38f3c6c1344a80ce842aa7afac9e051