### PR TITLE
add github ribbon; make download green

### DIFF
--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -11,8 +11,9 @@
       <div class="row">
         <div class="col-lg-3 col-md-1 col-sm-1"></div>
         <div class="col-lg-3 col-md-5 col-sm-5">
-          <a class="btn btn-danger btn-lg btn-block" href="/downloads" role="button">Download {{ page.julia_version }}</a>
-          <a class="link extra-link" href="/benchmarks">&nbsp;Benchmarks</a>
+          <a class="btn btn-success btn-lg btn-block" href="/downloads" role="button">Download {{ page.julia_version }}</a>
+          <a class="link extra-link" href="https://github.com/JuliaLang/julia">&nbsp; Source</a>
+          <a class="link extra-link" href="/benchmarks">&nbsp; Benchmarks</a>
           <br /><br />
           <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
         </br/>


### PR DESCRIPTION
- changes the download button to green
- adds a red github ribbon linking to the julia repo

Before | After
---|---
<img width="768" alt="old" src="https://user-images.githubusercontent.com/10854026/43675979-42bc86aa-97e9-11e8-94a5-e07e109530f1.png"> | <img width="768" alt="new" src="https://user-images.githubusercontent.com/10854026/43675981-482860aa-97e9-11e8-80de-d4a39ed8e7d6.png">

Note: I know little about jekyll, so I just winged it concerning how i included the ribbon in its own file and such (monkey see, monkey do). It works with and without the alert though, so thats something
