### PR TITLE
RFC: use three buttons in jumbotron

### DIFF
--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -9,17 +9,24 @@
         Julia is a highly productive language that runs fast
       </p>
       <div class="row">
+        <div class="col-lg-4 col-md-1 col-sm-1"></div>
+        <div class="col-lg-4 col-md-5 col-sm-5">
+          <a class="btn btn-success btn-lg btn-block" href="/downloads" role="button">Download {{ page.julia_version }}</a>
+        </div>
+        <div class="col-lg-4 col-md-1 col-sm-1"></div>
+      </div>
+      </br>
+      </br>
+      <div class="row">
         <div class="col-lg-3 col-md-1 col-sm-1"></div>
         <div class="col-lg-3 col-md-5 col-sm-5">
-          <a class="btn btn-danger btn-lg btn-block" href="/downloads" role="button">Download {{ page.julia_version }}</a>
-          <a class="link extra-link" href="/benchmarks">&nbsp;Benchmarks</a>
-          <br /><br />
+          <a class="btn btn-danger btn-sm btn-block" href="/benchmarks" role="button">Benchmarks</a>
+          <p></p>
           <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
         </br/>
-
         </div>
         <div class="col-lg-3 col-md-5 col-sm-5 docs">
-          <a class="btn btn-primary btn-lg btn-block" href="//docs.julialang.org" role="button">Documentation</a>
+          <a class="btn btn-primary btn-sm btn-block" href="//docs.julialang.org" role="button">Documentation</a>
           <a class="link extra-link" href="//docs.julialang.org/en/stable/manual/introduction/#man-introduction-1">&nbsp; Manual</a>
           <a class="link extra-link" href="//docs.julialang.org/en/stable/stdlib/base/">&nbsp; Standard Library</a><br />
           <a class="link extra-link" href="//docs.julialang.org/en/stable/devdocs/reflection/">&nbsp; Developer Documentation</a>

--- a/v2/css/app.css
+++ b/v2/css/app.css
@@ -359,8 +359,16 @@ h4.card-title {
 }
 
 .btn-primary {
-  background-color: #4D64AE;
-  border-color: #4D64AE;
+  background-color: #9259a3;
+  border-color: #9259a3;
+}
+.btn-success {
+  background-color: #399746;
+  border-color: #399746;
+}
+.btn-danger {
+  background-color: #ca3c32;
+  border-color: #ca3c32;
 }
 .link {
   color: #4D64AE;


### PR DESCRIPTION
So this is more of a inspiration/discussion than a PR I think. Essentially I tried to do three things

- make the download button the primary eye catcher
- make the Benchmarks more discoverable
- mimic the Julia logo with the button layout

<img width="768" alt="screen shot 2018-08-04 at 13 58 46" src="https://user-images.githubusercontent.com/10854026/43676337-725368a6-97ef-11e8-8820-b2d41de1203a.png">

Thoughts?