### PR TITLE
0.6.4 has no ARMs

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -93,24 +93,6 @@ title:  Julia Downloads
           </td>
         </tr>
         <tr>
-          <th> Generic Linux Binaries for ARM </th>
-          <td colspan="3">
-            <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/0.6/julia-0.6.4-linux-armv7l.tar.gz">32-bit (armv7-a hard float)</a>
-            (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/0.6/julia-0.6.4-linux-armv7l.tar.gz.asc">GPG</a>)
-          </td>
-          <td colspan="3">
-            <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/0.6/julia-0.6.4-linux-aarch64.tar.gz">64-bit (armv8-a)</a>
-            (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/0.6/julia-0.6.4-linux-aarch64.tar.gz.asc">GPG</a>)
-          </td>
-        </tr>
-        <tr>
-          <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-          <td colspan="6">
-            <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.6/julia-0.6.4-freebsd-x86_64.tar.gz">64-bit</a>
-            (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.6/julia-0.6.4-freebsd-x86_64.tar.gz.asc">GPG</a>)
-          </td>
-        </tr>
-        <tr>
           <th> Source </th>
           <td colspan="2">
             <a href="https://github.com/JuliaLang/julia/releases/download/v0.6.3/julia-0.6.4.tar.gz">Tarball</a>
@@ -133,7 +115,7 @@ title:  Julia Downloads
         Please see <a href="platform.html">platform specific instructions</a> if you have
         trouble installing Julia.
         Checksums for this release are available in both <a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.6.4.md5">MD5</a> and
-        <a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.6.3.sha256">SHA256</a> format.
+        <a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.6.4.sha256">SHA256</a> format.
       </p>
 
       <p>


### PR DESCRIPTION
We don't have binaries for Linux ARMv7, AArch64, or FreeBSD. Not sure how these links got added here, because they aren't there on the old site: http://www_old.julialang.org/downloads/.