### PR TITLE
Make column smaller for blog posts on large screens

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,7 +9,7 @@ layout: homepage
 <div class="container">
 
   <div class="row">
-    <div class="col-12">
+    <div class="col-12 col-lg-8 offset-lg-2">
       <h1>{{ title }}</h1>
 
 <div id="blogpost">


### PR DESCRIPTION
Blog posts have long lines on large screens, making it very unpleasant to read imo.

This PR reduces the width to 2/3 of what it was and centers the column.

Before
![Before](https://user-images.githubusercontent.com/194764/43765479-b388d3f6-9a38-11e8-9edb-cebdcc26f2d2.png)

After
![After](https://user-images.githubusercontent.com/194764/43765615-0aa71fe4-9a39-11e8-9a71-eb137b20bee3.png)

