### PR TITLE
Update the website for 1.0

### DIFF
--- a/_includes/footermenu.html
+++ b/_includes/footermenu.html
@@ -5,10 +5,10 @@
           <h6>Download</h6>
           <ul class="nav flex-column">
             <li class="nav-item">
-              <a class="nav-link" href="downloads/index.html">Julia v</a>
+              <a class="nav-link" href="downloads/index.html">Julia v1.0.0</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="downloads/index.html">Julia v0.7.0-rc2</a>
+              <a class="nav-link" href="downloads/oldreleases.html">Older</a>
             </li>
           </ul>
         </div>

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -11,7 +11,7 @@ title:  Julia Downloads
 
   <div class="row">
     <div class="col-12">
-      <h1>Current Release (v0.7.0)</h1>
+      <h1>Current Release (v1.0.0)</h1>
     </div>
   </div>
 
@@ -68,8 +68,8 @@ title:  Julia Downloads
         <tbody>
           <tr>
             <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7.0-win32.exe">32-bit</a> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7.0-win64.exe">64-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0.0-win32.exe">32-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.0-win64.exe">64-bit</a> </td>
           </tr>
           <tr>
             <td colspan="6">Windows 7/Windows Server 2012 users also require
@@ -78,32 +78,38 @@ title:  Julia Downloads
           </tr>
           <tr>
             <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.7/julia-0.7.0-mac64.dmg">10.8+ 64-bit</a> </td>
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.0/julia-1.0.0-mac64.dmg">10.8+ 64-bit</a> </td>
           </tr>
           <tr>
             <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz">32-bit</a>
-              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.0-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.0-linux-i686.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.0-linux-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.0-linux-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Generic Linux Binaries for ARM <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/julia-1.0.0-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/julia-1.0.0-linux-armv7l.tar.gz.asc">GPG</a>)
             </td>
           </tr>
           <tr>
             <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.0-freebsd-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
             </td>
           </tr>
           <tr>
             <th> Source </th>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz">Tarball</a>
-                  (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz.asc">GPG</a>)
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0/julia-1.0.0.tar.gz">Tarball</a>
+                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0/julia-1.0.0.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz">Tarball with dependencies</a>
-              (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz.asc">GPG</a>)
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0/julia-1.0.0-full.tar.gz">Tarball with dependencies</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0/julia-1.0.0-full.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v0.7.0">GitHub</a> </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.0.0">GitHub</a> </td>
           </tr>
         </tbody>
       </table>
@@ -113,75 +119,14 @@ title:  Julia Downloads
       <p>
         Please see <a href="platform.html">platform specific instructions</a> if you have
         trouble installing Julia.
-        Checksums for this release are available in both <a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.7.0.md5">MD5</a> and
-        <a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.7.0.sha256">SHA256</a> format.
+        Checksums for this release are available in both <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.0.md5">MD5</a> and
+        <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.0.sha256">SHA256</a> format.
       </p>
 
       <p>
         If the provided download files do not work for you, please <a href="https://github.com/JuliaLang/julia/issues">file an
         issue in the Julia project</a>.
       </p>
-    </div>
-  </div>
-
-  <br />
-
-  <div class="row">
-    <div class="col-12">
-      <h2>Upcoming Release (v1.0.0-rc1)</h2>
-      <p>
-          We are currently testing a release candidate version for the first major release of Julia, v1.0.0.
-          Please see <a href="platform.html">platform specific instructions</a> if you have trouble installing Julia.
-          As with other releases, checksums for this release are available in both
-          <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.0-rc1.md5">MD5</a>
-          and <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.0-rc1.sha256">SHA256</a> format.
-          Download the release candidate version here, and please report any issues to the
-          <a href="https://github.com/JuliaLang/julia/issues">issue tracker</a> on Github.
-      </p>
-
-      <table class="downloads table table-hover table-responsive table-bordered">
-        <tbody>
-          <tr>
-            <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0.0-rc1-win32.exe">32-bit</a> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.0-rc1-win64.exe">64-bit</a> </td>
-          </tr>
-          <tr>
-            <td colspan="6">Windows 7/Windows Server 2012 users also require
-              <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in">TLS "Easy Fix" update</a>,
-              and <a href="https://docs.microsoft.com/en-us/powershell/wmf/readme">Windows Management Framework 3.0 or later</a></td>
-          </tr>
-          <tr>
-            <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.0/julia-1.0.0-rc1-mac64.dmg">10.8+ 64-bit</a> </td>
-          </tr>
-          <tr>
-            <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.0-rc1-linux-i686.tar.gz">32-bit</a>
-              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.0-rc1-linux-i686.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.0-rc1-linux-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.0-rc1-linux-x86_64.tar.gz.asc">GPG</a>)
-            </td>
-          </tr>
-          <tr>
-            <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.0-rc1-freebsd-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.0-rc1-freebsd-x86_64.tar.gz.asc">GPG</a>)
-            </td>
-          </tr>
-          <tr>
-            <th> Source </th>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0-rc1/julia-1.0.0-rc1.tar.gz">Tarball</a>
-                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0-rc1/julia-1.0.0-rc1.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0-rc1/julia-1.0.0-rc1-full.tar.gz">Tarball with dependencies</a>
-              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.0-rc1/julia-1.0.0-rc1-full.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.0.0-rc1">GitHub</a> </td>
-          </tr>
-        </tbody>
-      </table>
     </div>
   </div>
 

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -134,6 +134,57 @@ title:  Julia Downloads
 
   <div class="row">
     <div class="col-12">
+      <h2>Previous release (v0.7.0)</h2>
+      <table class="downloads table table-hover table-responsive table-bordered">
+        <tbody>
+          <tr>
+            <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7.0-win32.exe">32-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7.0-win64.exe">64-bit</a> </td>
+          </tr>
+          <tr>
+            <td colspan="6">Windows 7/Windows Server 2012 users also require
+              <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in">TLS "Easy Fix" update</a>,
+              and <a href="https://docs.microsoft.com/en-us/powershell/wmf/readme">Windows Management Framework 3.0 or later</a></td>
+          </tr>
+          <tr>
+            <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.7/julia-0.7.0-mac64.dmg">10.8+ 64-bit</a> </td>
+          </tr>
+          <tr>
+            <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Source </th>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz">Tarball</a>
+                  (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz">Tarball with dependencies</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v0.7.0">GitHub</a> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <br />
+
+  <div class="row">
+    <div class="col-12">
       <h2>Older Releases</h2>
       <p>
         Older releases of Julia for all platforms are available on the <a href="oldreleases.html">Older releases page</a>.

--- a/downloads/nightlies.html
+++ b/downloads/nightlies.html
@@ -39,11 +39,6 @@ title:  Julia Downloads (nightly binaries)
             <td> <a href="https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz">64-bit</a> </td>
         </tr>
         <tr>
-            <th> Generic Linux binaries for ARM </th>
-            <td> <a href="https://julialangnightlies-s3.julialang.org/bin/linux/armv7l/julia-latest-linuxarmv7l.tar.gz">32-bit (armv7-a hard float)</a> </td>
-            <td> <a href="https://julialangnightlies-s3.julialang.org/bin/linux/aarch64/julia-latest-linuxaarch64.tar.gz">64-bit (armv8-a)</a> </td>
-        </tr>
-        <tr>
             <th> Fedora/RHEL/CentOS/SL packages (.rpm) </th>
             <td colspan="3"> <a href="https://copr.fedoraproject.org/coprs/nalimilan/julia-nightlies/">32/64-bit</a> </td>
         </tr>

--- a/downloads/oldreleases.html
+++ b/downloads/oldreleases.html
@@ -19,6 +19,51 @@ title:  Julia Downloads (Old releases)
 
       <br />
 
+      <h2>v0.7.0</h2>
+      <table class="downloads table table-hover table-responsive table-bordered">
+        <tbody>
+          <tr>
+            <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7.0-win32.exe">32-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7.0-win64.exe">64-bit</a> </td>
+          </tr>
+          <tr>
+            <td colspan="6">Windows 7/Windows Server 2012 users also require
+              <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in">TLS "Easy Fix" update</a>,
+              and <a href="https://docs.microsoft.com/en-us/powershell/wmf/readme">Windows Management Framework 3.0 or later</a></td>
+          </tr>
+          <tr>
+            <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.7/julia-0.7.0-mac64.dmg">10.8+ 64-bit</a> </td>
+          </tr>
+          <tr>
+            <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Source </th>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz">Tarball</a>
+                  (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz">Tarball with dependencies</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v0.7.0">GitHub</a> </td>
+          </tr>
+        </tbody>
+      </table>
+
       <h2>v0.6.4</h2>
       <table class="downloads table table-hover table-bordered">
         <tbody>

--- a/downloads/oldreleases.html
+++ b/downloads/oldreleases.html
@@ -19,51 +19,6 @@ title:  Julia Downloads (Old releases)
 
       <br />
 
-      <h2>v0.7.0</h2>
-      <table class="downloads table table-hover table-responsive table-bordered">
-        <tbody>
-          <tr>
-            <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7.0-win32.exe">32-bit</a> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7.0-win64.exe">64-bit</a> </td>
-          </tr>
-          <tr>
-            <td colspan="6">Windows 7/Windows Server 2012 users also require
-              <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in">TLS "Easy Fix" update</a>,
-              and <a href="https://docs.microsoft.com/en-us/powershell/wmf/readme">Windows Management Framework 3.0 or later</a></td>
-          </tr>
-          <tr>
-            <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/0.7/julia-0.7.0-mac64.dmg">10.8+ 64-bit</a> </td>
-          </tr>
-          <tr>
-            <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz">32-bit</a>
-              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-linux-i686.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz.asc">GPG</a>)
-            </td>
-          </tr>
-          <tr>
-            <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/0.7/julia-0.7.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
-            </td>
-          </tr>
-          <tr>
-            <th> Source </th>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz">Tarball</a>
-                  (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz">Tarball with dependencies</a>
-              (<a href="https://github.com/JuliaLang/julia/releases/download/v0.7.0/julia-0.7.0-full.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v0.7.0">GitHub</a> </td>
-          </tr>
-        </tbody>
-      </table>
-
       <h2>v0.6.4</h2>
       <table class="downloads table table-hover table-bordered">
         <tbody>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: homepage
 title:  The Julia Language
-julia_version: v0.7
+julia_version: v1.0
 ---
 
 {% comment %} {% include alerts.html %} {% endcomment %}


### PR DESCRIPTION
Changes include:

* Setting download links on downloads/index.html to point to 1.0.0
* Moving 0.7.0 to the older releases page
* Setting the big button on the front page to v1.0
* Changing the footer to point to 1.0 and "older" rather than "Julia v"
  and "Julia v0.7.0-rc2"