### PR TITLE
Fix broken links in blog posts

### DIFF
--- a/_includes/footermenu.html
+++ b/_includes/footermenu.html
@@ -5,10 +5,10 @@
           <h6>Download</h6>
           <ul class="nav flex-column">
             <li class="nav-item">
-              <a class="nav-link" href="downloads/index.html">Julia v1.0.0</a>
+              <a class="nav-link" href="https://julialang.org/downloads/index.html">Julia v1.0.0</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="downloads/oldreleases.html">Older</a>
+              <a class="nav-link" href="https://julialang.org/downloads/oldreleases.html">Older</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
The relative links will break within blog posts e.g. within [Julia 1.0](https://julialang.org/blog/2018/08/one-point-zero) the link will become `https://julialang.org/blog/2018/08/downloads/index.html`.

I hope the absolute links work 😜 🤷‍♂️