### PR TITLE
Minimal blog layout fixes

### DIFF
--- a/v2/css/app.css
+++ b/v2/css/app.css
@@ -403,7 +403,7 @@ img.ecosystem-image {
 }
 
 img {
-  /* max-width: 100%; */
+  max-width: 100%;
 }
 
 .page-heading .main-heading {
@@ -483,4 +483,18 @@ blockquote p {
 
 #main-jumbo {
   padding: 3rem 2rem;
+}
+
+code, table.benchmarks tbody {
+  font: 9pt Monaco, 'Consolas', monospace;
+}
+
+pre {
+  border: 1px solid #ddd;
+  background: rgb(250, 250, 250);
+  margin: 1em -1.5em;
+  padding: 1em 1.5em;
+  overflow: auto;
+  direction: ltr;
+  border-radius: 5px;
 }


### PR DESCRIPTION
Fixes the giant images and poorly-formatted code (#102); the other big thing still missing from blog formatting is `syntax.css` (syntax highlighting). I'm not sure why the img max-width was commented out before, so this might break something else.