### PR TITLE
Fix broken anchor tag for JuliaDB in Ecosystems

### DIFF
--- a/_includes/ecosystem.html
+++ b/_includes/ecosystem.html
@@ -99,7 +99,7 @@
                   <a href = "https://github.com/denizyuret/Knet.jl">Knet.jl</a>),
                   <a href = "http://juliaml.github.io"> machine learning </a> and AI. Julia’s mathematical syntax makes it an ideal way to express algorithms just as they are written in papers, build trainable models with
                   <a href = "http://www.juliadiff.org">automatic differentiation</a>,
-                  <a href = "https://github.com/JuliaGPU/CuArrays.jl">GPU acceleration</a> and support for terabytes of data with <a href="http://juliadb.org"JuliaDB</a>.
+                  <a href = "https://github.com/JuliaGPU/CuArrays.jl">GPU acceleration</a> and support for terabytes of data with <a href="http://juliadb.org">JuliaDB</a>.
                 </p>
                 <p>
                   Julia's rich machine learning and statistics ecosystem includes capabilities for


### PR DESCRIPTION
Under Ecosystems, in the Machine Learning tab, the "a" tag for JuliaDB is missing its closing ">", messing up what text gets used as the link.

Currently, the link looks like this:

<img width="722" alt="screen shot 2018-08-29 at 3 22 34 pm" src="https://user-images.githubusercontent.com/2618447/44810433-b0d99780-ab9f-11e8-918e-69a88cc0a14a.png">


This PR fixes it.