### PR TITLE
Fix usage: enthusiastic vs enthused

### DIFF
--- a/_includes/ecosystem.html
+++ b/_includes/ecosystem.html
@@ -137,7 +137,7 @@
                   <a href = "https://github.com/JuliaDynamics"> (JuliaDynamics)</a>, quantitative economics
                   <a href = "https://github.com/QuantEcon">(QuantEcon)</a>, astronomy
                   <a href = "http://juliaastro.github.io"> (JuliaAstro)</a></li> and ecology
-                  <a href = "https://github.com/EcoJulia">(EcoJulia)</a></li>. With a set of highly enthused
+                  <a href = "https://github.com/EcoJulia">(EcoJulia)</a></li>. With a set of highly enthusiastic
                   developers and maintainers from various parts of the scientific community, this ecosystem will only continue to get
                   bigger and bigger.
                 </p>


### PR DESCRIPTION
Minor prose usage fix: "enthused" is the past-tense verb form of "enthuse"; "enthusiastic" is the adjective.