### PR TITLE
use 1.0 in footer

### DIFF
--- a/_includes/footermenu.html
+++ b/_includes/footermenu.html
@@ -5,7 +5,7 @@
           <h6>Download</h6>
           <ul class="nav flex-column">
             <li class="nav-item">
-              <a class="nav-link" href="/downloads/index.html">Julia v1.0.0</a>
+              <a class="nav-link" href="/downloads/index.html">Julia v1.0</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="/downloads/oldreleases.html">Older</a>


### PR DESCRIPTION
Seems unnecessary to specify the patch version (we also dont do that on the first page download button)