### PR TITLE
downloads/platform.html: fix angle brackets

### DIFF
--- a/downloads/platform.html
+++ b/downloads/platform.html
@@ -47,8 +47,8 @@ title:  Platform specific instructions for installing Julia
 
       <h2>macOS</h2>
       <p>
-        On Mac, a <code>Julia-<version>.dmg</code> file is provided, which contains Julia.app. Installation is the same as any other Mac software --
-        copy the <code>Julia-<version>.app</code> to your hard-drive (anywhere) or run from the disk image. Julia runs on macOS 10.8 and later releases.
+        On Mac, a <code>Julia-&lt;version&gt;.dmg</code> file is provided, which contains Julia.app. Installation is the same as any other Mac software --
+        copy the <code>Julia-&lt;version&gt;.app</code> to your hard-drive (anywhere) or run from the disk image. Julia runs on macOS 10.8 and later releases.
       </p>
 
       <p>


### PR DESCRIPTION
If raw angle brackets are used wrapping a word in a HTML document, that fragment is interpreted as an HTML tag that's not recognized by the browser, and ignored in the rendered page altogether.

This change replaces the angle brackets by named entities so that they are rendered in the page as expected.