### PR TITLE
TLS easy fix should no longer be required

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -57,8 +57,7 @@ title:  Julia Downloads
           </tr>
           <tr>
             <td colspan="6">Windows 7/Windows Server 2012 users also require
-              <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in">TLS "Easy Fix" update</a>,
-              and <a href="https://docs.microsoft.com/en-us/powershell/wmf/overview">Windows Management Framework 3.0 or later</a></td>
+              <a href="https://docs.microsoft.com/en-us/powershell/wmf/overview">Windows Management Framework 3.0 or later</a></td>
           </tr>
           <tr>
             <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
@@ -137,8 +136,7 @@ title:  Julia Downloads
           </tr>
           <tr>
             <td colspan="6">Windows 7/Windows Server 2012 users also require
-              <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in">TLS "Easy Fix" update</a>,
-              and <a href="https://docs.microsoft.com/en-us/powershell/wmf/overview">Windows Management Framework 3.0 or later</a></td>
+              <a href="https://docs.microsoft.com/en-us/powershell/wmf/overview">Windows Management Framework 3.0 or later</a></td>
           </tr>
           <tr>
             <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>


### PR DESCRIPTION
Should now be fixed now that libgit2 has been updated (see https://github.com/JuliaLang/julia/issues/26167#issuecomment-428787263).