### PR TITLE
Mention transitional 0.7 right before the 1.0 downloads

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -49,6 +49,13 @@ title:  Julia Downloads
       <h2>Current stable release (v1.0.1)</h2>
       <p> <a href="#0.7.0">
         If transitioning from Julia 0.6.0 strongly consider working the the transitional Julia v0.7.0 release rather than moving directly and completely to v1.0.0.
+        Versions 1.0.0 and 0.7.0 are largely equivalent, with the primary difference being that 0.7.0 includes deprecation warnings
+        for functionality and behavior changed between previous releases and 1.0.0. For example, invoking deprecated methods
+        will emit a warning in 0.7.0 but will cause a MethodError in 1.0.0 as they have been removed.
+        It is thus often useful to have a copy of julia 0.7 even if working in 1.0 to allow the checking of what a 0.6 method has been deprecated to,
+        as 0.6.
+
+        Note that 1.0.x versions contain bugfixes not available on 0.7 releases.
       </a></p>
       
       <table class="downloads table table-hover table-responsive table-bordered">
@@ -124,13 +131,6 @@ title:  Julia Downloads
       <h2 id="0.7.0">Previous stable release (v0.7.0)</h2>
       <p>
         Julia v0.7.0 is a transitional release, intended to aid the transition from Julia v0.6, to Julia v1.0.
-        Versions 1.0.0 and 0.7.0 are largely equivalent, with the primary difference being that 0.7.0 includes deprecation warnings
-        for functionality and behavior changed between previous releases and 1.0.0. For example, invoking deprecated methods
-        will emit a warning in 0.7.0 but will cause a MethodError in 1.0.0 as they have been removed.
-        It is thus often useful to have a copy of julia 0.7 even if working in 1.0 to allow the checking of what a 0.6 method has been deprecated to,
-        as 0.6.
-
-        Note that 1.0.x versions contain bugfixes not available on 0.7 releases.
       </p>
       
       <table class="downloads table table-hover table-responsive table-bordered">

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -47,6 +47,10 @@ title:  Julia Downloads
   <div class="row">
     <div class="col-12">
       <h2>Current stable release (v1.0.1)</h2>
+      <p> <a href="#0.7.0">
+        If transitioning from Julia 0.6.0 strongly consider working the the transitional Julia v0.7.0 release rather than moving directly and completely to v1.0.0.
+      </a></p>
+      
       <table class="downloads table table-hover table-responsive table-bordered">
         <tbody>
           <tr>
@@ -110,15 +114,6 @@ title:  Julia Downloads
         If the provided download files do not work for you, please <a href="https://github.com/JuliaLang/julia/issues">file an
         issue in the Julia project</a>.
       </p>
-
-      <p>
-        You may be interested, especially as an existing package author or maintainer, in downloading Julia v0.7.0, shown below.
-        Versions 1.0.0 and 0.7.0 are largely equivalent, with the primary difference being that 0.7.0 includes deprecation warnings
-        for functionality and behavior changed between previous releases and 1.0.0. For example, invoking deprecated methods
-        will emit a warning in 0.7.0 but will cause an (intentional) runtime error in 1.0.0.
-
-        Note that 1.0.x versions contain bugfixes not available on 0.7 releases.
-      </p>
     </div>
   </div>
 
@@ -126,7 +121,18 @@ title:  Julia Downloads
 
   <div class="row">
     <div class="col-12">
-      <h2>Previous stable release (v0.7.0)</h2>
+      <h2 id="0.7.0">Previous stable release (v0.7.0)</h2>
+      <p>
+        Julia v0.7.0 is a transitional release, intended to aid the transition from Julia v0.6, to Julia v1.0.
+        Versions 1.0.0 and 0.7.0 are largely equivalent, with the primary difference being that 0.7.0 includes deprecation warnings
+        for functionality and behavior changed between previous releases and 1.0.0. For example, invoking deprecated methods
+        will emit a warning in 0.7.0 but will cause a MethodError in 1.0.0 as they have been removed.
+        It is thus often useful to have a copy of julia 0.7 even if working in 1.0 to allow the checking of what a 0.6 method has been deprecated to,
+        as 0.6.
+
+        Note that 1.0.x versions contain bugfixes not available on 0.7 releases.
+      </p>
+      
       <table class="downloads table table-hover table-responsive table-bordered">
         <tbody>
           <tr>


### PR DESCRIPTION
In an attempt to avoid:

  - https://discourse.julialang.org/t/what-happened-to-base-colon/16513
  - https://discourse.julialang.org/t/moving-from-v0-6-to-v1-0-has-been-so-annoying/15740
  - https://discourse.julialang.org/t/void-not-defined-version-problem/14183
  - https://discourse.julialang.org/t/loaderror-parallel/15126/
  - https://discourse.julialang.org/t/sort-a-dims-1-mixing-rows/16086 (kinda)
  - https://discourse.julialang.org/t/base-conversion-hex-bin-octal/15969|
  - https://discourse.julialang.org/t/value-of-e/15958/3
  - https://discourse.julialang.org/t/is-there-a-replacement-for-abstractsparsematrix/15429
  - https://discourse.julialang.org/t/undefined-variable-errors-when-upgrading-from-0-6-to-1-0/15432
  - https://discourse.julialang.org/t/preallocating-an-array-with-a-given-size-in-julia-1-0/14438
  - https://discourse.julialang.org/t/error-in-read-data-in-julia-v1-0/13308

And probably others.

I have made reference to 0.7. before the 1.0 download section.
I know there is already a notice *below* the 1.0 download section,
but I think people are not seeing that.
Because they stop reading once they find the download link.

I am hoping putting a notice **above** will help.
 