### PR TITLE
Set download links to 1.0.2

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -46,7 +46,7 @@ title:  Julia Downloads
 
   <div class="row">
     <div class="col-12">
-      <h2>Current stable release (v1.0.1)</h2>
+      <h2>Current stable release (v1.0.2)</h2>
       <p> <a href="#0.7.0">
         If transitioning from Julia 0.6.0, strongly consider working with the transitional Julia v0.7.0 release rather than moving directly and completely to v1.0.0.
         Versions 1.0.0 and 0.7.0 are largely equivalent, with the primary difference being that 0.7.0 includes deprecation warnings
@@ -61,8 +61,8 @@ title:  Julia Downloads
         <tbody>
           <tr>
             <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0.1-win32.exe">32-bit</a> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.1-win64.exe">64-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0.2-win32.exe">32-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.2-win64.exe">64-bit</a> </td>
           </tr>
           <tr>
             <td colspan="6">Windows 7/Windows Server 2012 users also require
@@ -70,15 +70,15 @@ title:  Julia Downloads
           </tr>
           <tr>
             <th> macOS Package (.dmg) <a href="platform.html#macos">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.0/julia-1.0.1-mac64.dmg">10.8+ 64-bit</a> </td>
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.0/julia-1.0.2-mac64.dmg">10.8+ 64-bit</a> </td>
           </tr>
           <tr>
             <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.1-linux-i686.tar.gz">32-bit</a>
-              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.1-linux-i686.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.2-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.2-linux-i686.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.2-linux-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.2-linux-x86_64.tar.gz.asc">GPG</a>)
             </td>
           </tr>
           <tr>
@@ -90,19 +90,19 @@ title:  Julia Downloads
           </tr>
           <tr>
             <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.1-freebsd-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.1-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            <td colspan="6"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.2-freebsd-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.2-freebsd-x86_64.tar.gz.asc">GPG</a>)
             </td>
           </tr>
           <tr>
             <th> Source </th>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.1/julia-1.0.1.tar.gz">Tarball</a>
-                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.1/julia-1.0.1.tar.gz.asc">GPG</a>)
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.2/julia-1.0.2.tar.gz">Tarball</a>
+                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.2/julia-1.0.2.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.1/julia-1.0.1-full.tar.gz">Tarball with dependencies</a>
-              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.1/julia-1.0.1-full.tar.gz.asc">GPG</a>)
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.2/julia-1.0.2-full.tar.gz">Tarball with dependencies</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.2/julia-1.0.2-full.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.0.1">GitHub</a> </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.0.2">GitHub</a> </td>
           </tr>
         </tbody>
       </table>
@@ -112,8 +112,8 @@ title:  Julia Downloads
       <p>
         Please see <a href="platform.html">platform specific instructions</a> if you have
         trouble installing Julia.
-        Checksums for this release are available in both <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.1.md5">MD5</a> and
-        <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.1.sha256">SHA256</a> format.
+        Checksums for this release are available in both <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.2.md5">MD5</a> and
+        <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.0.2.sha256">SHA256</a> format.
       </p>
 
       <p>


### PR DESCRIPTION
There will be binaries available for ARMv7, but the build has not finished. (Each ARMv7 build takes >24 hours to complete.) I'll get that updated separately once it's finished. I figured I'd might as well move forward with the rest of the platforms rather than holding everything up waiting for ARM.