### PR TITLE
Fix link in downloads

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -47,15 +47,15 @@ title:  Julia Downloads
   <div class="row">
     <div class="col-12">
       <h2>Current stable release (v1.0.2)</h2>
-      <p> <a href="#0.7.0">
-        If transitioning from Julia 0.6.0, strongly consider working with the transitional Julia v0.7.0 release rather than moving directly and completely to v1.0.0.
+      <p> 
+        If transitioning from Julia 0.6.0, strongly consider working with the transitional Julia <a href="#0.7.0">0.7.0 release</a> rather than moving directly and completely to v1.0.0.
         Versions 1.0.0 and 0.7.0 are largely equivalent, with the primary difference being that 0.7.0 includes deprecation warnings
         for functionality and behavior changed between previous releases and 1.0.0. For example, invoking deprecated methods
         will emit a warning in 0.7.0 but will cause a MethodError in 1.0.0 as they have been removed.
         It is thus often useful to have a copy of julia 0.7 even if working in 1.0 to allow the checking of what a 0.6 method has been deprecated to.
 
         Note that 1.0.x versions contain bugfixes not available on 0.7 releases.
-      </a></p>
+      </p>
       
       <table class="downloads table table-hover table-responsive table-bordered">
         <tbody>

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -48,7 +48,7 @@ title:  Julia Downloads
     <div class="col-12">
       <h2>Current stable release (v1.0.2)</h2>
       <p> 
-        If transitioning from Julia 0.6.0, strongly consider working with the transitional Julia <a href="#0.7.0">0.7.0 release</a> rather than moving directly and completely to v1.0.0.
+        If transitioning from Julia 0.6.0, strongly consider working with the transitional Julia <a href="#0.7.0">v0.7.0 release</a> rather than moving directly and completely to v1.0.0.
         Versions 1.0.0 and 0.7.0 are largely equivalent, with the primary difference being that 0.7.0 includes deprecation warnings
         for functionality and behavior changed between previous releases and 1.0.0. For example, invoking deprecated methods
         will emit a warning in 0.7.0 but will cause a MethodError in 1.0.0 as they have been removed.


### PR DESCRIPTION
Per slack, currently the whole paragraph under "current stable release" is a link. It looks janky and people identified it as a bug. 

cc @StefanKarpinski @ararslan idk who else