### PR TITLE
Update descriptors on main page

### DIFF
--- a/_includes/languagefeatures.html
+++ b/_includes/languagefeatures.html
@@ -28,7 +28,7 @@
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Optionally Typed</h4>
+      <h4>Optionally typed</h4>
       <p>
         Julia has a rich language of descriptive datatypes, and type declarations can
         be used to clarify and solidify programs.
@@ -45,19 +45,15 @@
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Technical</h4>
+      <h4>Easy to use</h4>
       <p>
-        Julia excels at numerical computing. Its syntax is great for math, many numeric
-        datatypes are supported, and parallelism is available out of the box.
-        Julia's multiple dispatch is a natural fit for defining number and array-like
-        datatypes.
+        Julia has high level syntax, making it an accessible language for programmers from any background or experience level.
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Composable</h4>
+      <h4>Open source</h4>
       <p>
-        Julia packages naturally work well together. Matrices of unit quantities, or data table
-        columns of currencies and colors, just work — and with good performance.
+        Julia is free for everyone to use, and all source code is publicly viewable on GitHub.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Add "Easy to use" and "Open source" as descriptors for Julia. As suggested by @ViralBShah in issue #135, use these new descriptors to replace "Technical" and "Composable".

Thanks!