### PR TITLE
Restructure learning page

### DIFF
--- a/learning/index.html
+++ b/learning/index.html
@@ -8,59 +8,42 @@ title:  Learning Julia
 <br>
 <br>
 <div class="container">
-    <h1> Online tutorials </h1>
-        <p>
-        We stream an online tutorial series that you can watch live or after the presentation has finished. We offer an introduction to Julia about once per month, as well as tutorials on other topics.
-        </p>
-        <p>
-        Get jupyter notebooks for all past tutorials <a href="https://github.com/JuliaComputing/JuliaBoxTutorials">here</a>
-        or run them directly on <a href="https://juliabox.com">JuliaBox</a>.
-        </p>
-        <p>
-        Check out a past introduction here, or see upcoming events below.
-        </p>
-        <br>
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/8h8rQyEpiZA" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-        <br>
-        <br>
-        <h3> Upcoming </h3>
 
-        <ul>
+<h1 id="tutorials">Tutorials</h1>
+<h3> with a video component </h3>
+<p>
+Get jupyter notebooks for the following youtube tutorials <a href="https://github.com/JuliaComputing/JuliaBoxTutorials">here</a>
+or run them directly on <a href="https://juliabox.com">JuliaBox</a>.
+</p>
 
-          <li> <a href= "https://www.youtube.com/watch?v=8h8rQyEpiZA"> Intro to Julia </a>, by Jane Herriman, on Wednesday, November 21 @ 10AM PST/1PM EST/19:00 CET/23:30 IST </li>
+<ul>
+    <li> <a href= "https://www.youtube.com/watch?v=fMa1qSg_LxA"> Intro to Julia (version 1.0) </a>, by Jane Herriman </li>
+    <li> <a href= "https://youtu.be/SLE0vz85Rqo"> Intro to Julia for data science</a>, by Huda Nassar </li>
+    <li> <a href="https://www.youtube.com/watch?v=OFPNph-WxLM">Intro to the Queryverse, a Julia data science stack</a>,
+        by David Anthoff </li>
+    <li> <a href="https://www.youtube.com/watch?v=0-Xsts_s5W">Intro to Julia Data Frames</a>,
+        by Bogumił Kamiński </li>
+    <li> <a href="https://www.youtube.com/watch?v=13hqE_1a158">Intro to dynamical systems in Julia</a>,
+        by George Datseris </li>
+    <li> <a href="https://youtu.be/LbTbs-0pOuc">Introducción a Julia en español</a>,
+        by Miguel Raz Guzmán </li>
+    <li> <a href="https://www.youtube.com/watch?v=d5SzUh2_ono">Intro to JuliaDB, a package for working with large persistent data sets</a>,
+        by Josh Day and Shashi Gowda </li>
+    <li> <a href="https://www.youtube.com/watch?v=KPEqYtEd-zY">Intro to solving differential equations in Julia</a>,
+        by Chris Rackauckas </li>
+    <li> <a href = "https://www.youtube.com/watch?v=4igzy3bGVkQ">Intro to Julia (version 0.6)</a>,
+        by Jane Herriman </li>
+</ul>
 
-          <li> <a href= "https://www.youtube.com/watch?v=BvSZqhDeuaA"> Intro to Julia </a>, by Jane Herriman, on Wednesday, December 19 @ 7AM PST/9AM CST/10AM EST/16:00 CET/20:30 IST </li>
-
-        </ul>
-
-        <h3>Past </h3>
-
-        <ul>
-            
-            <li> <a href= "https://www.youtube.com/watch?v=fMa1qSg_LxA"> Intro to Julia </a>, by Jane Herriman, (October 26, 2018) </li>
-            <li>Intro to Julia, by Jane Herriman (August 31, 2018) </li>
-            <li> <a href= "https://youtu.be/SLE0vz85Rqo"> Intro to Julia for data science </a>, by Huda Nassar (July 25, 2018) </li>
-            <li>Intro to Julia, by Jane Herriman (July 20, 2018) </li>
-            <li> <a href="https://www.youtube.com/watch?v=OFPNph-WxLM">Intro to the Queryverse, a Julia data science stack</a>,
-                by David Anthoff (June 14, 2018) </li>
-            <li> Intro to Julia, by Jane Herriman (June 8, 2018) </li>
-            <li> <a href="https://www.youtube.com/watch?v=0-Xsts_s5W">Intro to Julia Data Frames</a>,
-                by Bogumił Kamiński (May 24, 2018) </li>
-            <li> <a href="https://www.youtube.com/watch?v=13hqE_1a158">Intro to dynamical systems in Julia</a>,
-                by George Datseris (May 10, 2018) </li>
-            <li> Intro to Julia, by Jane Herriman (May 4, 2018) </li>
-            <li> <a href="https://youtu.be/LbTbs-0pOuc">Introducción a Julia en español</a>,
-                by Miguel Raz Guzmán (April 7, 2018) </li>
-            <li> Intro to Julia, by Jane Herriman (April 6, 2018) </li>
-            <li> <a href="https://www.youtube.com/watch?v=d5SzUh2_ono">Intro to JuliaDB, a package for working with large persistent data sets</a>,
-                by Josh Day and Shashi Gowda (February 28, 2018) </li>
-            <li> Intro to Julia, by Jane Herriman (February 15, 2018) </li>
-            <li> <a href="https://www.youtube.com/watch?v=KPEqYtEd-zY">Intro to solving differential equations in Julia</a>,
-                by Chris Rackauckas (February 6, 2018) </li>
-            <li> Intro to Julia by Jane Herriman (January 25, 2018) </li>
-            <li> <a href = "https://www.youtube.com/watch?v=4igzy3bGVkQ">Intro to Julia</a>,
-                by Jane Herriman (December 19, 2017) </li>
-     </ul>
+<br>
+<h3> written </h3>
+ <ul>
+   <li><a href="http://ucidatascienceinitiative.github.io/IntroToJulia/">A Deep Introduction to Julia for Data Science and Scientific Computing</a> by <a href="http://chrisrackauckas.com/">Chris Rackauckas</a></li>
+   <li><a href="https://lectures.quantecon.org/jl/index_learning_julia.html">Programming in Julia (Quantitative Economics)</a> - by Thomas J. Sargent and John Stachurski. Along with being a complete textbook with Julia code for macroeconomics, this also is a very good introduction to Julia.</li>
+   <li><a href="https://github.com/bkamins/The-Julia-Express">The Julia Express</a> (featuring Julia 1.0) by <a href="http://bogumilkaminski.pl">Bogumił Kamiński</a></li>
+   <li><a href="https://en.wikibooks.org/wiki/Introducing_Julia">Introducing Julia wikibook</a></li>
+   <li><a href="https://github.com/BenLauwens/ThinkJulia.jl">ThinkJulia</a></li>
+ </ul>}
 
 <h1 id="books">Books</h1>
 
@@ -86,16 +69,6 @@ title:  Learning Julia
   <li><a href="https://www.amazon.com/dp/1788998790">Hands-On Computer Vision with Julia</a> by Dmitrijs Cudihins (202 pages; published: June 2018; ISBN: 9781788998796). Explore the various packages in Julia that support image processing and build neural networks for video processing and object tracking.</li>
   <li><a href="http://bookstore.siam.org/sl03">Iterative Solution of Symmetric Quasi-Definite Linear Systems</a> by Dominique Orban and Mario Arioli. This book is intended for researchers and advanced graduate students in computational optimization, computational fluid dynamics, computational linear algebra, data assimilation, and virtually any computational field in which saddle-point systems occur. <a href="https://github.com/JuliaSmoothOptimizers/Krylov.jl">Krylov.jl</a> is the Julia package that accompanies the book. <a href="https://epubs.siam.org/doi/book/10.1137/1.9781611974737">Ebook</a> for SIAM subscribers.  </li>
   <li><a href="https://www.packtpub.com/application-development/julia-10-programming-cookbook">Julia 1.0 Programming Cookbook</a> by B. Kamiński, P. Szufel (460 pages; published: November 2018; ISBN: 9781788998369)</li>
-</ul>
-
-<h1 id="tutorials">Tutorials</h1>
-
-<ul>
-  <li><a href="http://ucidatascienceinitiative.github.io/IntroToJulia/">A Deep Introduction to Julia for Data Science and Scientific Computing</a> by <a href="http://chrisrackauckas.com/">Chris Rackauckas</a></li>
-  <li><a href="https://lectures.quantecon.org/jl/index_learning_julia.html">Programming in Julia (Quantitative Economics)</a> - by Thomas J. Sargent and John Stachurski. Along with being a complete textbook with Julia code for macroeconomics, this also is a very good introduction to Julia.</li>
-  <li><a href="https://github.com/bkamins/The-Julia-Express">The Julia Express</a> (featuring Julia 1.0) by <a href="http://bogumilkaminski.pl">Bogumił Kamiński</a></li>
-  <li><a href="https://en.wikibooks.org/wiki/Introducing_Julia">Introducing Julia wikibook</a></li>
-  <li><a href="https://github.com/BenLauwens/ThinkJulia.jl">ThinkJulia</a></li>
 </ul>
 
 <h1 id="resources">Resources</h1>
@@ -212,7 +185,7 @@ a</li>
     <ul>
       <li><a href="http://www.hadsel.vgs.no/AnsattOversikt.aspx?personid=16964&mid1=15925</a>, [REA3034] Programmering og modellering (Programming and modeling with Julia and Snap), 2018/19 (High school lecturer Olav A Marschall, M.sc. Computer Science)</li>
     </ul>
- </li> 
+ </li>
   <li>IIT Indore <!--22.52036,75.920723-->
     <ul>
       <li><a href="https://github.com/ivanslapnicar/GIAN-Applied-NLA-Course">ApplNLA</a>, Modern Applications of Numerical Linear Algebra (Prof. <a href="http://www.fesb.unist.hr/~slap/index1.html">Ivan Slapnicar</a>), June 2016</li>


### PR DESCRIPTION
Changes:
- Create one section on tutorials that includes (unique) past youtube tutorials and written tutorials. 
- Delete bits about schedule on upcoming and past tutorials, since these may not be happening regularly going forward.

Thanks!