### PR TITLE
Fix size of code font

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -210,7 +210,7 @@ table.benchmarks {
 /* Inline code and code blocks */
 
 code, table.benchmarks tbody {
-  font: 9pt Monaco, 'Consolas', monospace;
+  font: Monaco, 'Consolas', monospace;
 }
 
 pre {


### PR DESCRIPTION
Before this PR: If you have Monaco installed, then the font of include code is always 9pts, no matter the context.
This looks particular bad in headings,
but it is also wrong for body content,
Which has height 1rem not 9pt,
this would be praticularly obvious on certain mobile devices I think.

### Before:
![before screenshot](https://user-images.githubusercontent.com/5127634/51428486-31a33980-1bfc-11e9-836b-48abd9c4265c.png)


--- 
### After

![after screenshot](https://user-images.githubusercontent.com/5127634/51428483-28b26800-1bfc-11e9-8386-0b7e7977a5a5.png)
