### PR TITLE
Fix buttons linking to newest julia version.

### DIFF
--- a/_includes/footermenu.html
+++ b/_includes/footermenu.html
@@ -5,7 +5,7 @@
           <h6>Download</h6>
           <ul class="nav flex-column">
             <li class="nav-item">
-              <a class="nav-link" href="/downloads/index.html">Julia v1.0</a>
+              <a class="nav-link" href="/downloads/index.html">Julia {{ page.julia_version }}</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="/downloads/oldreleases.html">Older</a>
@@ -16,7 +16,7 @@
           <h6>Documentation</h6>
           <ul class="nav flex-column">
             <li class="nav-item">
-              <a class="nav-link" href="https://docs.julialang.org/en/v1/">Julia v1.0</a>
+              <a class="nav-link" href="https://docs.julialang.org/en/v1/">Julia {{ page.julia_version }}</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="https://juliacn.github.io/JuliaZH.jl/latest/index.html">Julia (CN)</a>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: homepage
 title:  The Julia Language
-julia_version: v1.0
+julia_version: v1.1
 ---
 
 {% comment %} {% include alerts.html %} {% endcomment %}


### PR DESCRIPTION
The buttons on the index homepage still show `v1.0` instead of `v1.1`.