### PR TITLE
Add link to julia docker images on the download page.

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -35,6 +35,7 @@ title:  Julia Downloads
           <li> In the terminal using the built-in Julia command line.
           <li> In the browser on <a href="https://www.juliabox.com">JuliaBox.com</a> with Jupyter notebooks.
                 No installation is required -- just point your browser there, login and start computing.
+          <li> Using <a href="https://docs.docker.com/">Docker</a> images from <a href = "https://hub.docker.com/_/julia">Docker Hub</a> maintained by the <a href="https://github.com/docker-library/julia">Docker Community</a>.
           <li> <a href="http://juliacomputing.com/products/juliapro.html">JuliaPro</a> by
                 <a href="http://juliacomputing.com">Julia Computing</a>
                 includes Julia and the <a href="http://junolab.org" >Juno IDE</a>, along with access to a curated set of packages for plotting, optimization, machine learning, databases and much more (requires registration).


### PR DESCRIPTION
xref https://github.com/docker-library/julia/issues/28, cc @tianon, @yosifkit