### PR TITLE
Fix a hyperlink on the "learning" page

### DIFF
--- a/learning/index.html
+++ b/learning/index.html
@@ -39,7 +39,7 @@ or run them directly on <a href="https://juliabox.com">JuliaBox</a>.
 <h3> written </h3>
  <ul>
    <li><a href="http://ucidatascienceinitiative.github.io/IntroToJulia/">A Deep Introduction to Julia for Data Science and Scientific Computing</a> by <a href="http://chrisrackauckas.com/">Chris Rackauckas</a></li>
-   <li><a href="https://lectures.quantecon.org/jl/index_learning_julia.html">Programming in Julia (Quantitative Economics)</a> - by Thomas J. Sargent and John Stachurski. Along with being a complete textbook with Julia code for macroeconomics, this also is a very good introduction to Julia.</li>
+   <li><a href="https://lectures.quantecon.org/jl/">Programming in Julia (Quantitative Economics)</a> - by Thomas J. Sargent and John Stachurski. Along with being a complete textbook with Julia code for macroeconomics, this also is a very good introduction to Julia.</li>
    <li><a href="https://github.com/bkamins/The-Julia-Express">The Julia Express</a> (featuring Julia 1.0) by <a href="http://bogumilkaminski.pl">Bogumił Kamiński</a></li>
    <li><a href="https://en.wikibooks.org/wiki/Introducing_Julia">Introducing Julia wikibook</a></li>
    <li><a href="https://github.com/BenLauwens/ThinkJulia.jl">ThinkJulia</a></li>


### PR DESCRIPTION
The current link leads to a 404 error. The updated one does not.