### PR TITLE
Update Julia manual links

### DIFF
--- a/blog/_posts/2017-01-21-moredots.md
+++ b/blog/_posts/2017-01-21-moredots.md
@@ -123,7 +123,7 @@ function-call overloading [(Bezanson, 2015: chapter 4)](https://github.com/JeffB
 but we chose to go in a different direction.
 
 Instead, starting in Julia 0.5, *any* function `f(x)` can be applied elementwise
-to an array `X` with the ["dot call" syntax `f.(X)`](http://docs.julialang.org/en/stable/manual/functions/#dot-syntax-for-vectorizing-functions).
+to an array `X` with the ["dot call" syntax `f.(X)`](https://docs.julialang.org/en/v1/manual/functions/#man-vectorized-1).
 Thus, the *caller* decides which functions to vectorize.  In Julia 0.6,
 "traditionally" vectorized library functions like `sqrt(X)` are [deprecated](https://github.com/JuliaLang/julia/pull/17302) in
 favor of `sqrt.(X)`, and dot operators
@@ -424,7 +424,7 @@ arrays of different shapes (see below) turns out to be subtle to
 implement efficiently without losing generality. The current
 implementation relies on a metaprogramming feature that Julia provides
 called [generated
-functions](http://docs.julialang.org/en/stable/manual/metaprogramming/#generated-functions)
+functions](https://docs.julialang.org/en/v1/manual/metaprogramming/#Generated-functions-1)
 in order to get compile-time specialization on the number and types of
 the arguments.  An alternative solution to the inlining and
 specialization issues would be to build the `broadcast` function into
@@ -608,7 +608,7 @@ syntax invokes `broadcast`, not `map`.) The basic differences are:
   not (it can "expand" smaller containers to match larger ones).
 
 * `map` treats all arguments as *containers by default*, and in particular
-  expects its arguments to [act as iterators](http://docs.julialang.org/en/latest/manual/interfaces.html#man-interface-iteration-1).
+  expects its arguments to [act as iterators](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-iteration-1).
   In contrast, `broadcast` treats its arguments as *scalars by default* (i.e., as 0-dimensional arrays
   of one element), except for a few types like `AbstractArray` and `Tuple`
   that are explicitly declared to be broadcast containers.


### PR DESCRIPTION
This update the links to the Julia manual for this blog post, previous links give a 404 error.