### PR TITLE
Add AArch64 links for 1.2.0-rc1

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -239,7 +239,9 @@ title:  Julia Downloads
             <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.2.0-rc1-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
               (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.2.0-rc1-linux-armv7l.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="3"> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.2.0-rc1-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.2.0-rc1-linux-aarch64.tar.gz.asc">GPG</a>)
+            </td>
           </tr>
           <tr>
             <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>


### PR DESCRIPTION
I missed this one when putting up the page the first time.