### PR TITLE
Add student blogs to GSoC/JSoC overview page

### DIFF
--- a/blog/_posts/2019-05-31-jsoc19.md
+++ b/blog/_posts/2019-05-31-jsoc19.md
@@ -15,43 +15,43 @@ Season of Contributions (JSoC), using some community funds. Details on the progr
 
 So we are excited to see what our impressive set of students achieve this summer. Here is a list of all the projects for GSoC and JSoC 2019
 
-|  | Name | Project |
-| ------------- | ------------- | ------------- |
-|1|Aadesh Deshmukh|Improved flowpipe/guard intersections for hybrid reachability using Taylor models|
-|2|Adam Jozefiak|Extending the DiffEqOperators.jl Package|
-|3|Ching-Wen Cheng|Practical implementation of BERT models for Julia|
-|4|Tushar Sinha|Implementing Blossom V Algorithm for Computing Minimum Cost Perfect Matching in a General Graph|
-|5|Jerry Chen|Heterogeneous Computing in Julia:  MAGMA binding|
-|6|Shashank Shekhar|Gaussian process integration between Turing and Stheno|
-|7|Elisabeth Rosch|Fitting Neural Differential Equations in Julia|
-|8|Divyanshu Gupta|Quantum Algorithms for Differential Equations|
-|9|Langwen Huang|Implicit Runge-Kutta algorithms with more robust Jacobian reuse mechanism and sparse Jacobian support|
-|10|Kartikey Gupta|Reinforcement Learning environments for Julia|
-|11|Koustav Chowdhury|Implementation of Robin Hood Hashing scheme in Julia|
-|12|Kirill Zubov|Implement package for solving high-dimensional partial differential equations using Neural Networks|
-|13|Ludovico Bessi|Accelerating optimization via machine learning with different surrogate models|
-|14|Pankaj Mishra|Automatic Computation of Sparse Jacobians|
-|15|Sharan Yalburgi|Variational Inference Methods in Turing.jl|
-|16|Yashvardhan Sharma|Implementing Charibde: The Hybrid Algorithm for constrained Interval Optimisation|
-|17|Shivin Srivastava|Efficient Finite Difference Discretizations of Partial Differential Operators|
-|18|Saurabh Agarwal|Implementing Parallel Extrapolation Algorithms|
-|19|Sumegh Roychowdhury|Special Functions|
-|20|Yash Raj Gupta|Standard Compliant Interval Arithmetic Library in Julia|
-|21|Yash Patel|ULMFiT:Universal Language Model Fine-Tuning for Text Classification and Sentiment Analysis|
-|22|Akshay Jain|Trace Estimation of Matrix on Analytic Functions such as Matrix Inverse and Log-Determinant|
-|23|Saumya Shah|Model Zoo for Turing.jl|
-|24|Arda Akdemir|De-Bruijn Graph Constructor Package for De-novo Genome Assembly|
-|25|Andreas Peter|Differentiable Tensor Networks|
-|26|Manjunath Bhat|Enriching Model Zoo with Deep Learning Models|
-|27|Abhinav Mehndiratta|GraphBLAS Implementation|
-|28|Kanav Gupta|Performance Enhancements and General Fixes|
-|29|Tor Fjelde|Variational Inference for Turing.jl|
-|30|Brandon Taylor|Query.jl to SQL translation|
-|31|Raghvendra Gupta|Sparsifying Neural Networks using Sensitivity driven Regularization|
-|32|Avik Pal|Differentiable Ray Tracer in Julia|
-|33|Ayush Kaushal|Practical Models for Named Entity Recognition and Part-of-Speech Tagging|
-|34|Shreyas Kowshik|Addition Of Baseline Models To Model Zoo|
-|35|Deepesh Thakur|Native Julia ODE, SDE, DAE, DDE, and (S)PDE Solvers|
-|36|Tejan Karmali|Differentiable Duckietown|
-|37|Morten Piibeleht|Rejuvenating Documenter|
-|38|Johnny Chen|Towards Better Images.jl Ecosystem|
+|  | Name | Project | Blog |
+| ------------- | ------------- | ------------- | :-------------: |
+|1|Aadesh Deshmukh|Improved flowpipe/guard intersections for hybrid reachability using Taylor models||
+|2|Adam Jozefiak|Extending the DiffEqOperators.jl Package||
+|3|Ching-Wen Cheng|Practical implementation of BERT models for Julia|[✔️](https://nextjournal.com/chengchingwen)|
+|4|Tushar Sinha|Implementing Blossom V Algorithm for Computing Minimum Cost Perfect Matching in a General Graph||
+|5|Jerry Chen|Heterogeneous Computing in Julia:  MAGMA binding||
+|6|Shashank Shekhar|Gaussian process integration between Turing and Stheno||
+|7|Elisabeth Rosch|Fitting Neural Differential Equations in Julia||
+|8|Divyanshu Gupta|Quantum Algorithms for Differential Equations||
+|9|Langwen Huang|Implicit Runge-Kutta algorithms with more robust Jacobian reuse mechanism and sparse Jacobian support||
+|10|Kartikey Gupta|Reinforcement Learning environments for Julia|[✔️](https://nextjournal.com/kraftpunk97)|
+|11|Koustav Chowdhury|Implementation of Robin Hood Hashing scheme in Julia|[✔️](https://nextjournal.com/eulerkochy)|
+|12|Kirill Zubov|Implement package for solving high-dimensional partial differential equations using Neural Networks||
+|13|Ludovico Bessi|Accelerating optimization via machine learning with different surrogate models|[✔️](https://nextjournal.com/ludoro)|
+|14|Pankaj Mishra|Automatic Computation of Sparse Jacobians|[✔️](https://nextjournal.com/pkj-m)|
+|15|Sharan Yalburgi|Variational Inference Methods in Turing.jl||
+|16|Yashvardhan Sharma|Implementing Charibde: The Hybrid Algorithm for constrained Interval Optimisation||
+|17|Shivin Srivastava|Efficient Finite Difference Discretizations of Partial Differential Operators||
+|18|Saurabh Agarwal|Implementing Parallel Extrapolation Algorithms||
+|19|Sumegh Roychowdhury|Special Functions||
+|20|Yash Raj Gupta|Standard Compliant Interval Arithmetic Library in Julia||
+|21|Yash Patel|ULMFiT:Universal Language Model Fine-Tuning for Text Classification and Sentiment Analysis||
+|22|Akshay Jain|Trace Estimation of Matrix on Analytic Functions such as Matrix Inverse and Log-Determinant|[✔️](https://nextjournal.com/akshayjain)|
+|23|Saumya Shah|Model Zoo for Turing.jl||
+|24|Arda Akdemir|De-Bruijn Graph Constructor Package for De-novo Genome Assembly|[✔️](https://ardakdemir.github.io/pages/gsoc.html)|
+|25|Andreas Peter|Differentiable Tensor Networks||
+|26|Manjunath Bhat|Enriching Model Zoo with Deep Learning Models||
+|27|Abhinav Mehndiratta|GraphBLAS Implementation||
+|28|Kanav Gupta|Performance Enhancements and General Fixes||
+|29|Tor Fjelde|Variational Inference for Turing.jl||
+|30|Brandon Taylor|Query.jl to SQL translation||
+|31|Raghvendra Gupta|Sparsifying Neural Networks using Sensitivity driven Regularization||
+|32|Avik Pal|Differentiable Ray Tracer in Julia||
+|33|Ayush Kaushal|Practical Models for Named Entity Recognition and Part-of-Speech Tagging||
+|34|Shreyas Kowshik|Addition Of Baseline Models To Model Zoo|[✔️](https://shreyas-kowshik.github.io/)|
+|35|Deepesh Thakur|Native Julia ODE, SDE, DAE, DDE, and (S)PDE Solvers||
+|36|Tejan Karmali|Differentiable Duckietown||
+|37|Morten Piibeleht|Rejuvenating Documenter|[✔️](http://mortenpi.eu/gsoc2019/latest/)|
+|38|Johnny Chen|Towards Better Images.jl Ecosystem||


### PR DESCRIPTION
I have added all the student blogs that I could find (they all have at least one blog post regarding JSoC 2019). If this gets merged, I will post a message in the #jsoc-standup and #ml-jsoc-standup slack channels and ask the students to give me a link to their blogs, so that we can complete this list.