### PR TITLE
Add further student blogs to GSoC/JSoC overview

### DIFF
--- a/blog/_posts/2019-05-31-jsoc19.md
+++ b/blog/_posts/2019-05-31-jsoc19.md
@@ -41,13 +41,13 @@ So we are excited to see what our impressive set of students achieve this summer
 |22|Akshay Jain|Trace Estimation of Matrix on Analytic Functions such as Matrix Inverse and Log-Determinant|[✔️](https://nextjournal.com/akshayjain)|
 |23|Saumya Shah|Model Zoo for Turing.jl||
 |24|Arda Akdemir|De-Bruijn Graph Constructor Package for De-novo Genome Assembly|[✔️](https://ardakdemir.github.io/pages/gsoc.html)|
-|25|Andreas Peter|Differentiable Tensor Networks||
-|26|Manjunath Bhat|Enriching Model Zoo with Deep Learning Models||
+|25|Andreas Peter|Differentiable Tensor Networks|[✔️](https://nextjournal.com/under-Peter)|
+|26|Manjunath Bhat|Enriching Model Zoo with Deep Learning Models|[✔️](https://medium.com/@manjunathbhat9920)|
 |27|Abhinav Mehndiratta|GraphBLAS Implementation||
 |28|Kanav Gupta|Performance Enhancements and General Fixes||
 |29|Tor Fjelde|Variational Inference for Turing.jl||
 |30|Brandon Taylor|Query.jl to SQL translation||
-|31|Raghvendra Gupta|Sparsifying Neural Networks using Sensitivity driven Regularization||
+|31|Raghvendra Gupta|Sparsifying Neural Networks using Sensitivity driven Regularization|[✔️](https://medium.com/@raghav090897)|
 |32|Avik Pal|Differentiable Ray Tracer in Julia||
 |33|Ayush Kaushal|Practical Models for Named Entity Recognition and Part-of-Speech Tagging||
 |34|Shreyas Kowshik|Addition Of Baseline Models To Model Zoo|[✔️](https://shreyas-kowshik.github.io/)|


### PR DESCRIPTION
I've collected three additional student blogs from my request on the #jsoc #jsoc-standup and #jsoc-ml-standup slack channels. I don't think I will get many more replies...

We now have collected 12 out of 38 student blogs. I guess many students didn't set up a blog or a nextjournal page yet. We might need to wait a another week or so...
Any ideas how we could collect the 26 remaining blogs? Maybe we could open a discourse post where the students can mention their blog URL after being asked by their mentors to do it?