### PR TITLE
community standards: clarify that it applies to verbal communication too

### DIFF
--- a/community/standards/index.html
+++ b/community/standards/index.html
@@ -19,8 +19,8 @@ title:  Julia Community
       <h3>Be respectful and inclusive</h3>
       <p>
         Please do not use overtly sexual language or imagery. Do not attack anyone based on any aspect of personal identity,
-        including gender, sexuality, politics, religion, ethnicity, race, age, or ability. Keep in mind that what you write in public forums is
-        read by many people who don't know you personally, so please refrain from making prejudiced or sexual jokes and comments –
+        including gender, sexuality, politics, religion, ethnicity, race, age, or ability. Keep in mind that what you write or say in public forums is
+        read or heard by many people who don't know you personally, so please refrain from making prejudiced or sexual jokes and comments –
         even ones that you might consider acceptable in private. Ask yourself if a comment or statement might make someone feel
         unwelcomed or like an outsider.
       </p><p>

--- a/community/standards/index.html
+++ b/community/standards/index.html
@@ -23,7 +23,7 @@ title:  Julia Community
         read by many people who don't know you personally, so please refrain from making prejudiced or sexual jokes and comments –
         even ones that you might consider acceptable in private. Ask yourself if a comment or statement might make someone feel
         unwelcomed or like an outsider.
-        <br />
+      </p><p>
         In particular, do not sexualize the term "Julia" or any other aspects of the project. While "Julia" is a female name in many
         parts of the world, the programming language is not a person and does not have a gender.
       </p>
@@ -33,7 +33,7 @@ title:  Julia Community
         All participants in the Julia community are expected to respect copyright laws and ethical attribution standards.
         This applies to both code and written materials, such as documentation or blog posts. Materials that violate the law,
         are plagiaristic, or ethically dubious in some way will be removed from officially-maintained lists of resources.
-        <br />
+      </p><p>
         If you believe one of these standards has been violated, you can either file an issue on an appropriate repository or
         confidentially contact the <a href="../stewards">Julia Stewards</a> at <a href="mailto:stewards@julialang.org">stewards@julialang.org</a>.
         Keep in mind that most mistakes are due to ignorance rather than malice.


### PR DESCRIPTION
This was written long pre-JuliaCon when written communication was all we ever did. These days it's entirely plausible that someone might be speaking, rather than writing, in a public forum which is part of the Julia community.