### PR TITLE
Fix #420: Change usage of highlightjs

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,6 @@
 <script src="/v2/js/jquery.min.js"></script>
 <script src="/v2/js/bootstrap.min.js"></script>
 <script src="/v2/js/platform.js"></script>
-<script src="/v2/js/app.js"></script>
 <script src="/v2/js/highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/v2/js/app.js
+++ b/v2/js/app.js
@@ -1,4 +1,0 @@
-$(function(){
-  // console.log(platform.os);
-  hljs.initHighlightingOnLoad();
-});


### PR DESCRIPTION
There was a slight issue with the old usage of highlightjs. Sometimes the page would finish loading before the initHighlightingOnLoad call. This would prevent syntax highlighting from being enabled.