### PR TITLE
add RHEOS.jl paper to publications

### DIFF
--- a/_publications/KBK19.md
+++ b/_publications/KBK19.md
@@ -1,0 +1,13 @@
+---
+type: "article"
+title: "RHEOS.jl -- A Julia Package for Rheology Data Analysis"
+journal: "Journal of Open Source Software"
+authors:
+- Jonathan Louis Kaplan
+- Alessandra Bonfanti
+- Alexandre J Kabla
+year: "2019"
+doi: "10.21105/joss.01700"
+packages:
+    RHEOS.jl: https://github.com/JuliaRheology/RHEOS.jl
+---


### PR DESCRIPTION
Adding our recent JOSS paper for a Julia-based software package:

https://github.com/JuliaRheology/RHEOS.jl

https://joss.theoj.org/papers/10.21105/joss.01700

