### PR TITLE
Update languagefeatures.html

### DIFF
--- a/_includes/languagefeatures.html
+++ b/_includes/languagefeatures.html
@@ -14,21 +14,21 @@
 
   <div class="row">
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Julia is fast!</h4>
+      <h3>Julia is fast!</h3>
       <p>
         Julia was designed from the beginning for <a href="/benchmarks/">high performance</a>.
         Julia programs compile to efficient native code for multiple platforms via LLVM.
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Dynamic</h4>
+      <h3>Dynamic</h3>
       <p>
         Julia is dynamically-typed, feels like a scripting language, and has good support
         for interactive use.
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Optionally typed</h4>
+      <h3>Optionally typed</h3>
       <p>
         Julia has a rich language of descriptive datatypes, and type declarations can
         be used to clarify and solidify programs.
@@ -36,7 +36,7 @@
     </div>
 
     <div class="col-lg-4 col-md-6 feature">
-      <h4>General</h4>
+      <h3>General</h3>
       <p>
         Julia uses multiple dispatch as a paradigm, making it easy to express
         many object-oriented and functional programming patterns.
@@ -45,13 +45,13 @@
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Easy to use</h4>
+      <h3>Easy to use</h3>
       <p>
         Julia has high level syntax, making it an accessible language for programmers from any background or experience level.
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>Open source</h4>
+      <h3>Open source</h3>
       <p>
         Julia is free for everyone to use, and all source code is publicly viewable on GitHub.
       </p>


### PR DESCRIPTION
Switching `h4` tags to `h3` since "A heading level is skipped."... 

"Why It Matters:
Headings provide document structure and facilitate keyboard navigation by users of assistive technology. These users may be confused or experience difficulty navigating when heading levels are skipped."