### PR TITLE
add RVM instructions for having a non-global gemset for using jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*~
 .*.sw?
 .DS_Store
-.ruby-version
-
-Gemfile.lock
+/.jekyll-metadata
+/.ruby-version
+/.ruby-gemset
+/Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -6,7 +6,22 @@ The Julia website is generated using GitHub pages and Jekyll, as [explained here
 
 After installing [`docker`](http://docker.com/), run `make run` to build and run the website within the a container built from the [`jekyll/jekyll` image](https://hub.docker.com/r/jekyll/jekyll/) that contains all the necessary prerequisites.  Modifying files will cause the website to rebuild in real time.
 
-## Running manually
+## Installing locally with RVM
+
+    # gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB # if next line fails, it'll tell you to do this first
+    curl -L get.rvm.io | bash -s stable --ruby # install rvm and ruby to $HOME
+    . ~/.profile # pick up rvm binary
+    echo www.julialang.org > .ruby-gemset # define a new gemset
+    cd . # make the gemset active
+    bundler update
+    # jekyll serve --incremental -H 0.0.0.0 -P 4000 -l --future --unpublished --drafts
+    jekyll serve --future
+
+
+If installing on macOS, you may need to have MacPorts or Homebrew installed first, and it still might not work at all, so YMMV.
+Also, it'll apparently break stuff if you previously used rb-env, so buyer-beware (https://github.com/rbenv/rbenv#how-it-works).
+
+## Installing globally, manually
 
 In short, be sure you have ruby installed, and then run these commands
 


### PR DESCRIPTION
I thought this might be helpful to someone. Hopefully the information is reasonably accurate—the best I can say is "it worked for me on an ubuntu server, and failed on macOS."