### PR TITLE
Update current release links to 1.3.0

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -42,11 +42,11 @@ title:  Julia Downloads
 
   <br />
 
-  <h2>Current stable release: v1.2.0 (Aug 20, 2019)</h2>
+  <h2>Current stable release: v1.3.0 (Nov 25, 2019)</h2>
   <p>
     Checksums for this release are available in
-    both <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.2.0.md5">MD5</a>
-    and <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.2.0.sha256">SHA256</a>
+    both <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.3.0.md5">MD5</a>
+    and <a href="https://julialang-s3.julialang.org/bin/checksums/julia-1.3.0.sha256">SHA256</a>
     formats.
   </p>
 
@@ -56,48 +56,48 @@ title:  Julia Downloads
         <tbody>
           <tr>
             <th> Windows (.exe) <a href="platform.html#windows">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.2/julia-1.2.0-win32.exe">32-bit</a> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.2/julia-1.2.0-win64.exe">64-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.2/julia-1.3.0-win32.exe">32-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.2/julia-1.3.0-win64.exe">64-bit</a> </td>
           </tr>
           <tr>
             <th> macOS 10.8+ (.dmg) <a href="platform.html#macos">[help]</a></th>
             <td colspan="3"> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.2/julia-1.2.0-mac64.dmg">64-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.2/julia-1.3.0-mac64.dmg">64-bit</a> </td>
           </tr>
           <tr>
             <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.2/julia-1.2.0-linux-i686.tar.gz">32-bit</a>
-              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.2/julia-1.2.0-linux-i686.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.2/julia-1.3.0-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.2/julia-1.3.0-linux-i686.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.3.0-linux-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.3.0-linux-x86_64.tar.gz.asc">GPG</a>)
             </td>
           </tr>
           <tr>
             <th> Generic Linux Binaries for ARM <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.2.0-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.2.0-linux-armv7l.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.3.0-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.3.0-linux-armv7l.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.2.0-linux-aarch64.tar.gz">64-bit (AArch64)</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.2.0-linux-aarch64.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.3.0-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.3.0-linux-aarch64.tar.gz.asc">GPG</a>)
             </td>
           </tr>
           <tr>
             <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
             <td colspan="3"> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.2/julia-1.2.0-freebsd-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.2/julia-1.2.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.2/julia-1.3.0-freebsd-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.2/julia-1.3.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
             </td>
           </tr>
           <tr>
             <th> Source </th>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0.tar.gz">Tarball</a>
-                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0.tar.gz.asc">GPG</a>)
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0/julia-1.3.0.tar.gz">Tarball</a>
+                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0/julia-1.3.0.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0-full.tar.gz">Tarball with dependencies</a>
-              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0-full.tar.gz.asc">GPG</a>)
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0/julia-1.3.0-full.tar.gz">Tarball with dependencies</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0/julia-1.3.0-full.tar.gz.asc">GPG</a>)
             </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.2.0">GitHub</a> </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.3.0">GitHub</a> </td>
           </tr>
         </tbody>
       </table>
@@ -174,71 +174,6 @@ title:  Julia Downloads
 
       <br />
 
-    </div>
-  </div>
-
-  <br />
-
-  <h2>Upcoming release: v1.3.0-rc5 (Nov 17, 2019)</h2>
-  <p>
-    We're currently testing release candidates for Julia v1.3.0, an upcoming minor release
-    in the 1.x series of releases. We encourage developers and interested users to try it
-    out and report any issues they encounter. As a prerelease, it should not be considered
-    production-ready; it's intended to give users a chance to try out 1.3 with their code
-    before the full release.
-  </p>
-
-  <div class="row">
-    <div class="col-12">
-      <table class="downloads table table-hover  table-bordered">
-        <tbody>
-          <tr>
-            <th> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.3/julia-1.3.0-rc5-win32.exe">32-bit</a> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.3/julia-1.3.0-rc5-win64.exe">64-bit</a> </td>
-          </tr>
-          <tr>
-            <th> macOS 10.8+ Package (.dmg) <a href="platform.html#macos">[help]</a></th>
-            <td colspan="3"> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.3/julia-1.3.0-rc5-mac64.dmg">64-bit</a> </td>
-          </tr>
-          <tr>
-            <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.3/julia-1.3.0-rc5-linux-i686.tar.gz">32-bit</a>
-              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.3/julia-1.3.0-rc5-linux-i686.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.0-rc5-linux-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.0-rc5-linux-x86_64.tar.gz.asc">GPG</a>)
-            </td>
-          </tr>
-          <tr>
-            <th> Generic Linux Binaries for ARM <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.0-rc5-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.0-rc5-linux-armv7l.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.3/julia-1.3.0-rc5-linux-aarch64.tar.gz">64-bit (AArch64)</a>
-                (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.3/julia-1.3.0-rc5-linux-aarch64.tar.gz.asc">GPG</a>)
-            </td>
-          </tr>
-          <tr>
-            <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
-            <td colspan="3"> </td>
-            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.3/julia-1.3.0-rc5-freebsd-x86_64.tar.gz">64-bit</a>
-                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.3/julia-1.3.0-rc5-freebsd-x86_64.tar.gz.asc">GPG</a>)
-            </td>
-          </tr>
-          <tr>
-            <th> Source </th>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0-rc5/julia-1.3.0-rc5.tar.gz">Tarball</a>
-                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0-rc5/julia-1.3.0-rc5.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0-rc5/julia-1.3.0-rc5-full.tar.gz">Tarball with dependencies</a>
-              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.3.0-rc5/julia-1.3.0-rc5-full.tar.gz.asc">GPG</a>)
-            </td>
-            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.3.0-rc5">GitHub</a> </td>
-          </tr>
-        </tbody>
-      </table>
     </div>
   </div>
 

--- a/downloads/oldreleases.html
+++ b/downloads/oldreleases.html
@@ -17,6 +17,57 @@ title:  Julia Downloads (Old releases)
         nor maintained anymore.
       </p>
 
+      <h2>v1.2.0 (Aug 20, 2019)</h2>
+      <table class="downloads table table-hover table-bordered">
+        <tbody>
+          <tr>
+            <th> Windows (.exe) <a href="platform.html#windows">[help]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.2/julia-1.2.0-win32.exe">32-bit</a> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.2/julia-1.2.0-win64.exe">64-bit</a> </td>
+          </tr>
+          <tr>
+            <th> macOS 10.8+ (.dmg) <a href="platform.html#macos">[help]</a></th>
+            <td colspan="3"> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.2/julia-1.2.0-mac64.dmg">64-bit</a> </td>
+          </tr>
+          <tr>
+            <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.2/julia-1.2.0-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.2/julia-1.2.0-linux-i686.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Generic Linux Binaries for ARM <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.2.0-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.2/julia-1.2.0-linux-armv7l.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.2.0-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+                (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.2.0-linux-aarch64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[help]</a></th>
+            <td colspan="3"> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.2/julia-1.2.0-freebsd-x86_64.tar.gz">64-bit</a>
+                (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.2/julia-1.2.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Source </th>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0.tar.gz">Tarball</a>
+                  (<a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0-full.tar.gz">Tarball with dependencies</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.2.0/julia-1.2.0-full.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.2.0">GitHub</a> </td>
+          </tr>
+        </tbody>
+      </table>
+
       <h2>v1.1.1 (May 16, 2019)</h2>
       <table class="downloads table table-hover  table-bordered">
         <tbody>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: homepage
 title:  The Julia Language
-julia_version: v1.2
+julia_version: v1.3
 ---
 <html lang="en">
 


### PR DESCRIPTION
1.2 is now in "old releases" and the homepage download link says 1.3.