### PR TITLE
resolve the occasional oddity with zooming in on the buttons

### DIFF
--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -13,17 +13,16 @@
 </br/>
       <div class="row">
         <div class="col-lg-3 col-md-1 col-sm-1"></div>
-        <div class="col-lg-3 col-md-auto col-sm-5">
+        <div class="col-lg-auto col-md-auto col-sm-auto">
           <a class="btn btn-success btn-lg btn-block" href="/downloads" role="button">Download {{ page.julia_version }}</a>
         </br/>
-
         </div>
-        <div class="col-lg-3 col-md-auto col-sm-5 docs">
+        <div class="col-lg-auto col-md-auto col-sm-auto docs">
           <a class="btn btn-primary btn-lg btn-block" href="//docs.julialang.org" role="button">Documentation</a>
         </br/>
         </div>
-        <div class="col-3 col-md-1 col-sm-1"></div>
-      </div>
+        <div class="col-lg-3 col-md-1 col-sm-1"></div>
+      </div>           
       <div clsss="row">
         <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
       </div>


### PR DESCRIPTION
In some circumstances (browsers + fonts), the text labeling the buttons can exceed the width of the button backgrounds. This should take care of that.  Additionally, a bugfix is present (`col-lg-3` in line 24 had been `col-3`). `col-<sz>-auto` was added to bootstrap  to handle related issues (https://github.com/twbs/bootstrap/issues/11346).

This takes https://github.com/JuliaLang/www.julialang.org/pull/492 further (that PR was incomplete).
<I don't know how to generate this website locally, so I cannot preview the change>