### PR TITLE
Change MCMC framework link to Turing

### DIFF
--- a/_includes/ecosystem.html
+++ b/_includes/ecosystem.html
@@ -106,7 +106,7 @@
                   <a href = "https://github.com/JuliaStats/GLM.jl">generalized linear models</a>,
                   <a href = "https://github.com/bensadeghi/DecisionTree.jl">decision trees</a>, and <a href = "https://github.com/JuliaStats/Clustering.jl">clustering</a>. You can also find packages for
                   <a href = "https://github.com/sisl/BayesNets.jl">Bayesian Networks</a> and
-                  <a href = "https://github.com/JuliaStats/Klara.jl">Markov Chain Monte Carlo</a>.
+                  <a href = "https://github.com/TuringLang/Turing.jl">Markov Chain Monte Carlo</a>.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
The previously linked Klara.jl is deprecated.