### PR TITLE
Adding macOS installation instructions

### DIFF
--- a/downloads/platform.html
+++ b/downloads/platform.html
@@ -70,17 +70,33 @@ title:  Platform specific instructions
 
       <h2 id='macOS'>macOS</h2>
       <p>
-        On macOS, a <code>Julia-&lt;version&gt;.dmg</code> file is provided, which contains Julia.app. Installation is the same as any other Mac software.
-        Drag the <code>Julia-&lt;version&gt;.app</code> to Applications. You can also run Julia from the disk image. Julia runs on macOS 10.8 and later releases.
+        On macOS, a <code>Julia-&lt;version&gt;.dmg</code> file is provided, which contains <code>Julia-&lt;version&gt;.app</code>. Installation is the same as any other Mac software.
+        Drag the <code>Julia-&lt;version&gt;.app</code> to Applications Folder's Shortcut. You can also run Julia from the disk image by opening the app. Julia runs on macOS 10.8 and later releases.
       </p>
   
       <p>
-        Add <code>julia</code> to the PATH by saving the following in your `~/.bash_history`. You can then also start Julia in the Terminal.<br />
-        <pre>export PATH=$PATH:/Applications/Julia-<version>.app/Contents/Resources/julia/bin/julia</pre>
+        To start running Julia from the Terminal, you can add <code>julia</code> to the PATH.
+        First, open up the Terminal and determine whether you are using <code>zsh</code> or <code>bash</code> as your Terminal shell.
+      </p>
+
+      <p>
+        If you are using <code>zsh</code>, type the following in the Terminal:
+        <pre>open -a TextEdit ~/.zshrc</pre>
+        If you are using <code>bash</code>, type the following in the Terminal:
+        <pre>open -a TextEdit ~/.bash_profile</pre>
       </p>
   
       <p>
-        Uninstall Julia by deleting Julia.app and the packages directory in <code>~/.julia</code>. Multiple Julia.app binaries can co-exist without interfering with each other.
+        The commands above should open up a shell profile page in a GUI text editor. <br />
+        Now, for both <code>zsh</code> and <code>bash</code> users, you can add the following to the bottom of the profile page: <br />
+        <pre>export PATH="/Applications/Julia-&lt;version&gt;.app/Contents/Resources/julia/bin:${PATH}"</pre>
+        Remember to replace the version of <code>Julia-&lt;version&gt;.app</code> above with the version of your Julia app.
+        Once that is done, you can close the shell profile page and quit Terminal.
+        Now, just simply open Terminal again, type in <code>julia</code> in it, and it should run your version of Julia!
+      </p>
+  
+      <p>
+        You can uninstall Julia by deleting Julia.app and the packages directory in <code>~/.julia</code>. Multiple Julia.app binaries can co-exist without interfering with each other.
         If you would also like to remove your preferences files, remove <code>~/.juliarc.jl</code> and <code>~/.julia_history</code>.
       </p>
 
@@ -155,6 +171,8 @@ title:  Platform specific instructions
         Julia can be installed using the <a href="https://brew.sh/">Homebrew package manager</a> as follows:
 
         <pre>brew cask install julia</pre>
+        
+        This automatically puts the binary into a directory in the user's PATH, so you can simply type <code>julia</code> to run Julia in the terminal.
       </p>
 
       <br />


### PR DESCRIPTION
Update platform.html.
This allows users to add Julia to PATH on macOS
Sample is here: https://julialang-test.netlify.com/downloads/platform.html
Resolves #525 
