### PR TITLE
Redirecting julialang.org/download to julialang.org/downloads (Improving PR #528)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,8 @@ navigation:
     title: GSoC
   - url: "https://juliacon.org"
     title: juliacon
+  - url: "/download/"
+    title: download
 collections:
   publications:
     permalink: /publications/:path
-include: [_redirects]

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,0 @@
-download/ https://julialang.org/downloads/

--- a/download/index.html
+++ b/download/index.html
@@ -1,0 +1,6 @@
+---
+layout: homepage
+title:  Julia Downloads Redirect
+---
+
+<meta http-equiv="refresh" content="0;url=https://julialang.org/downloads" />


### PR DESCRIPTION
Improving PR #528

This requires the line `gem 'jekyll-redirect-from'` in the Gemfile so if #528 was reverted, please add this here.

This method works both locally and on netlify.

test: https://julialang-test.netlify.com/downloads/