### PR TITLE
Updating the outdated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ then
 from the root of this repository to fetch all dependencies and install them locally.
 You only have to do this once.
 
-Now you need to check your ruber version by running `ruby -v` in the terminal. 
+Now you need to check your ruby version by running `ruby -v` in the terminal. 
 
 If you are on `ruby 2.6.3p62` or older run: 
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ You only have to do this once.
 
 Now you can run
 
-    ./bin/jekyll serve --future
+    bundle exec jekyll serve --future
 
 in the root of this repository to serve it, usually on [http://localhost:4000](http://localhost:4000).
 Or with other options, such as internet-visible on port 4444 with all drafts:
 
-    ./bin/jekyll serve --incremental -H 0.0.0.0 -P 4444 -l --future --unpublished --drafts
+    bundle exec jekyll serve --incremental -H 0.0.0.0 -P 4444 -l --future --unpublished --drafts
 
 You can then edit the sources and Jekyll will rebuild changed files. To see
 changes, reload the page you edited.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ then
 from the root of this repository to fetch all dependencies and install them locally.
 You only have to do this once.
 
-Now you can run
+Now you need to check your ruber version by running `ruby -v` in the terminal. 
+If you are on `ruby 2.6.3p62` or older run: 
+
+    ./bin/jekyll serve --future
+
+Else run:
 
     bundle exec jekyll serve --future
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Else run:
 
 in the root of this repository to serve it, usually on [http://localhost:4000](http://localhost:4000).
 Or with other options, such as internet-visible on port 4444 with all drafts:
+    
+    ./bin/jekyll serve --incremental -H 0.0.0.0 -P 4444 -l --future --unpublished --drafts 
+    
+The above code is for `ruby 2.6.3p62` or older. The below code is for any version that is newer. 
 
     bundle exec jekyll serve --incremental -H 0.0.0.0 -P 4444 -l --future --unpublished --drafts
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ from the root of this repository to fetch all dependencies and install them loca
 You only have to do this once.
 
 Now you need to check your ruber version by running `ruby -v` in the terminal. 
+
 If you are on `ruby 2.6.3p62` or older run: 
 
     ./bin/jekyll serve --future


### PR DESCRIPTION
As seen [here](https://help.github.com/en/github/working-with-github-pages/testing-your-github-pages-site-locally-with-jekyll), the command `./bin/jekyll serve` is now `bundle exec jekyll serve` instead.

I found out as `./bin/jekyll serve` didn't work for `ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin19]`