### PR TITLE
Update 404.html

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -8,11 +8,11 @@
   <p>
     It appears that you have stumbled upon a page on the Julia website
     that does not exist. You may find it useful to start at
-    [www.julialang.org](http://www.julialang.org), or navigate the Julia
+    <a href="http://docs.juliaplots.org/latest/backends/">http://www.julialang.org</a>, or navigate the Julia
     website using the links above.
 
-    For improvements to this website, please [file issues or submit
-    pull requests](https://github.com/julialang/www.julialang.org).
+    For improvements to this website, please <a href="https://github.com/julialang/www.julialang.org">file issues or submit
+    pull requests</a>.
   <p>
   </div>
   <br /><br />


### PR DESCRIPTION
Fixed links on 404 page from markdown format that wasn't rendering to HTML link formatting.