### PR TITLE
Fix ML&PL broken blog articles permalinks, fix inconsistant pi encoding

### DIFF
--- a/content/blog/2017-03-14-piday.md
+++ b/content/blog/2017-03-14-piday.md
@@ -1,7 +1,7 @@
 ---
 author: Simon Byrne, Luis Benet and David Sanders
 date: "2017-03-14T00:00:00Z"
-title: Some fun with &pi; in Julia
+title: Some fun with π in Julia
 slug: piday
 ---
 

--- a/content/blog/2017-12-06-ml&pl.md
+++ b/content/blog/2017-12-06-ml&pl.md
@@ -1,7 +1,9 @@
 ---
 date: "2017-12-06T00:00:00Z"
 title: On Machine Learning and Programming Languages
-slug: ml&pl
+slug: mlpl
+aliases:
+  - /blog/2017/12/ml&pl
 ---
 
 > Any sufficiently complicated machine learning system contains an ad-hoc, informally-specified, bug-ridden, slow implementation of half of a programming language.[^greenspun]

--- a/content/blog/2017-12-20-ml&pl-cn.md
+++ b/content/blog/2017-12-20-ml&pl-cn.md
@@ -1,7 +1,9 @@
 ---
 date: "2017-12-20T00:00:00Z"
 title: 机器学习与编程语言 (Simplified Chinese)
-slug: ml&pl-cn
+slug: mlpl-cn
+aliases:
+  - /blog/2017/12/ml&pl-cn
 ---
 
 > 任何足够复杂的机器学习系统，里面都拼凑了半个不规范，处处错误，且运行缓慢的编程语言。[^greenspun]

--- a/content/blog/2017-12-25-ml&pl-zh_tw.md
+++ b/content/blog/2017-12-25-ml&pl-zh_tw.md
@@ -1,7 +1,9 @@
 ---
 date: "2017-12-25T00:00:00Z"
 title: 機器學習以及程式語言(Traditional Chinese)
-slug: ml&pl-zh_tw
+slug: mlpl-zh_tw
+aliases:
+  - /blog/2017/12/ml&pl-zh_tw
 ---
 
 > 任何足夠複雜的機器學習系統都包含一個特別設置、不符規範、充滿 bug 又緩慢實作的程式語言半成品。[^greenspun]

--- a/content/blog/2018-03-14-pifonts.md
+++ b/content/blog/2018-03-14-pifonts.md
@@ -1,7 +1,7 @@
 ---
 author: Cormullion
 date: "2018-03-14T00:00:00Z"
-title: Some &pi;-ography
+title: Some π-ography
 slug: pifonts
 ---
 


### PR DESCRIPTION
I found 3 dead permalinks which were caused by `&` in the slugs. Hugo seemingly removes those from the URLs.
Given the time passed since the switch and that it might not be ideal to have `&` in URLs I thought it would be better to just add a redirect for the old permalinks and keep the current URLs.

I also fixed two πs that were encoded as character entity references which rendered inconsistently on the the page of the post and the list of blog posts.