### PR TITLE
Re-enable link to ARMv7 binaries.

### DIFF
--- a/layouts/downloads/list.html
+++ b/layouts/downloads/list.html
@@ -74,8 +74,8 @@
             </tr>
             <tr>
               <th> Generic Linux Binaries for ARM <a href="platform#linux-and-freebsd">[help]</a></th>
-              <td colspan="3"> Coming Soon <!-- <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.1-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
-                  (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.1-linux-armv7l.tar.gz.asc">GPG</a>) -->
+              <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.1-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+                  (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.3/julia-1.3.1-linux-armv7l.tar.gz.asc">GPG</a>)
               </td>
               <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.3/julia-1.3.1-linux-aarch64.tar.gz">64-bit (AArch64)</a>
                   (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.3/julia-1.3.1-linux-aarch64.tar.gz.asc">GPG</a>)


### PR DESCRIPTION
5d35489638d6260b6a3d5a284e36368451811991 seems to have been lost in the transition to Hugo, cc @ararslan 