### PR TITLE
Fix alignment of buttons in Homepage banner

### DIFF
--- a/layouts/partials/jumbotron.html
+++ b/layouts/partials/jumbotron.html
@@ -16,7 +16,7 @@
 -->
 </br/>
       <div class="row">
-        <div class="col-lg-3 col-md-1 col-sm-1"></div>
+        <div class="col"></div>
         <div class="col-lg-auto col-md-auto col-sm-auto">
           <a class="btn btn-success btn-lg btn-block" href="/downloads" role="button">Download {{ .Params.julia_version }}</a>
         </br/>
@@ -25,10 +25,12 @@
           <a class="btn btn-primary btn-lg btn-block" href="//docs.julialang.org" role="button">Documentation</a>
         </br/>
         </div>
-        <div class="col-lg-3 col-md-1 col-sm-1"></div>
+        <div class="col"></div>
       </div>           
-      <div clsss="row">
+      <div class="row">
+        <div class="col"></div>
         <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
+        <div class="col"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR intends to fix #592.

Here are some screenshots of the banner after this change:
Desktop:
![image](https://user-images.githubusercontent.com/1856425/73008632-3bfba300-3e0f-11ea-9582-4e810edaa396.png)
Tablet:
![image](https://user-images.githubusercontent.com/1856425/73008642-44ec7480-3e0f-11ea-9ae5-f0ab6a39e50b.png)
Mobile:
![image](https://user-images.githubusercontent.com/1856425/73008657-4b7aec00-3e0f-11ea-8bb2-3d7ba5281bbd.png)