### PR TITLE
Fix missing entries on /research

### DIFF
--- a/content/research/BCCKSVZ2018.md
+++ b/content/research/BCCKSVZ2018.md
@@ -8,7 +8,7 @@ authors:
  - Viral B. Shah
  - Jan Vitek
  - Lionel Zoubritzky
-year: 2018
+year: "2018"
 volume: 2
 issue: OOPSLA
 pages: "Article No. 120 "

--- a/content/research/GB19.md
+++ b/content/research/GB19.md
@@ -5,7 +5,7 @@ authors:
   - Koki Tsuyuzaki
   - Kentaro Shimizu
   - Itoshi Nikaido
-year: 2019
+year: "2019"
 journal: Genome Biology
 volume: 20
 issue: 31

--- a/content/research/H18.md
+++ b/content/research/H18.md
@@ -9,7 +9,7 @@ volume: 3
 pages: 692
 issn: 2475-9066
 doi: 10.21105/joss.00692
-year: 2018
+year: "2018"
 month: April
 packages:
   GeoStats.jl: https://github.com/juliohm/GeoStats.jl

--- a/content/research/HBC.md
+++ b/content/research/HBC.md
@@ -9,7 +9,7 @@ journal: Journal of Geophysical Research (Earth Surface)
 publisher: American Geophysical Union (AGU)
 issn: 2169-9011
 doi: 10.1029/2019JF005245
-year: 2019
+year: "2019"
 month: Nov
 packages:
   ImageQuilting.jl: https://github.com/juliohm/ImageQuilting.jl

--- a/content/research/HSBC17.md
+++ b/content/research/HSBC17.md
@@ -12,7 +12,7 @@ volume: 106
 pages: 18--32
 issn: 0098-3004
 doi: 10.1016/j.cageo.2017.05.012
-year: 2017
+year: "2017"
 month: May
 packages:
   ImageQuilting.jl: https://github.com/juliohm/ImageQuilting.jl

--- a/content/research/HZ19.md
+++ b/content/research/HZ19.md
@@ -10,7 +10,7 @@ volume: 131
 pages: 52--59
 issn: 0098-3004
 doi: 10.1016/j.cageo.2019.06.013
-year: 2019
+year: "2019"
 month: Oct
 packages:
   Variography.jl: https://github.com/juliohm/Variography.jl

--- a/content/research/KN18.md
+++ b/content/research/KN18.md
@@ -12,7 +12,7 @@ pages: 33--41
 issn: 1869-6104
 doi: 10.1515/gcc-2018-0004
 arxiv: 1703.09680
-year: 2018
+year: "2018"
 month: April
 packages:
   Groups.jl: https://git.wmi.amu.edu.pl/kalmar/Groups.jl

--- a/content/research/MS14.md
+++ b/content/research/MS14.md
@@ -4,7 +4,7 @@ title: "Bayesian estimation of discretely observed multi-dimensional diffusion p
 authors:
 - Frank van der Meulen
 - Moritz Schauer
-year: 2014
+year: "2014"
 doi: "10.1214/17-EJS1290"
 arxiv: 1406.4704
 packages:

--- a/content/research/README.md
+++ b/content/research/README.md
@@ -5,7 +5,7 @@ The frontmatter is sort of a YAML version of bibtex (but using unicode instead o
 The following fields are required:
 - title: the name of the paper
 - authors: the list of the authors. Note that this should be a YAML list, not "and" separated like bibtex
-- year
+- year: the year should be quoted ("YYYY")
 
 The format will also make use of the following fields:
 - journal

--- a/content/research/RPFNetal2018.md
+++ b/content/research/RPFNetal2018.md
@@ -12,7 +12,7 @@ authors:
  - Jon McAuliffe
  - Rollin Thomas
  - Prabhat
-year: 2018
+year: "2018"
 title: Cataloging the visible universe through Bayesian inference at petascale
 booktitle: International Parallel and Distributed Processing Symposium (IPDPS)
 arxiv: 1801.10277

--- a/content/research/ZAAF18.md
+++ b/content/research/ZAAF18.md
@@ -5,7 +5,7 @@ authors:
  - Alexander Liniger
  - Atsushi Sakai
  - Francesco Borrelli
-year: 2018
+year: "2018"
 booktitle: "2018 IEEE Conference on Decision and Control (CDC)"
 publisher: "IEEE"
 doi: "10.1109/CDC.2018.8619433"

--- a/content/research/ZBPCBV2018.md
+++ b/content/research/ZBPCBV2018.md
@@ -7,7 +7,7 @@ authors:
  - Benjamin Chung
  - Jeff Bezanson
  - Jan Vitek
-year: 2018
+year: "2018"
 volume: 2
 issue: OOPSLA
 pages: "Article No. 113 "


### PR DESCRIPTION
@juliohm noticed that some entries were missing from the research page.
For some reason the year in the yaml header needs to be quoted.
This PR fixes those entries for which this wasn't the case and now show up in the list.
I also added a note in the README.md of this requirement (ideally this shouldn't be one imo, but I don't know where it emanates from)