### PR TITLE
Improve GSoC projects (ML/SciML)

### DIFF
--- a/content/jsoc/gsoc/diffeq.md
+++ b/content/jsoc/gsoc/diffeq.md
@@ -1,10 +1,9 @@
 ---
 layout: single
-title:  DiffEq Projects – Summer of Code
+title:  Numerical Differential Equations Projects – Summer of Code
 ---
 
 # {{< get_param title >}}
-
 
 ## Native Julia ODE, SDE, DAE, DDE, and (S)PDE Solvers
 
@@ -203,27 +202,5 @@ numerical ODE solver libraries. Background in the numerical analysis of differen
 solvers is not required.
 
 **Expected Results**: Efficient and high-quality implementations of model transformation methods.
-
-**Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
-
-## Integration of FEniCS.jl with dolfin-adjoint + Zygote.jl for Scientific Machine Learning
-
-Scientific machine learning requires mixing scientific computing libraries with machine learning.
-[This blog post highlights how the tooling of Julia is fairly advanced in this field](https://www.stochasticlifestyle.com/the-essential-tools-of-scientific-machine-learning-scientific-ml/) compared to alternatives such as Python,
-but one area that has not been completely worked out is integration of automatic differentiation
-with partial differential equations.
-[FEniCS.jl](https://github.com/JuliaDiffEq/FEniCS.jl) is a wrapper to the
-[FEniCS](https://fenicsproject.org/) project for finite element solutions of partial differential
-equations. We would like to augment the Julia wrappers to allow for integration with Julia's
-automatic differentiation libraries like [Zygote.jl](https://github.com/FluxML/Zygote.jl) by
-using [dolfin-adjoint](http://www.dolfin-adjoint.org/en/release/). This would require setting up
-this library for automatic installation for Julia users and writing adjoint passes which utilize
-this adjoint builder library. It would result in the first total integration between PDEs and
-neural networks.
-
-**Recommended Skills**: A basic background in differential equations and Python. Having previous
-Julia knowledge is preferred but not strictly required.
-
-**Expected Results**: Efficient and high-quality implementations of adjoints for Zygote.jl over FEniCS.jl functions.
 
 **Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)

--- a/content/jsoc/gsoc/flux.md
+++ b/content/jsoc/gsoc/flux.md
@@ -1,13 +1,9 @@
 ---
 layout: page
-title: Flux
+title: Machine Learning Projects - Summer of Code
 ---
 
-# Google Summer of Code Projects
-
-Flux usually takes part in [Google Summer of Code](https://summerofcode.withgoogle.com), as part of the wider Julia organisation. We follow the same [rules and application guidelines](https://julialang.org/soc/ideas-page) as Julia, so please check there for more information on applying. Below are a set of ideas for potential projects (though you are welcome to explore anything you are interested in).
-
-Flux projects are typically very competitive; we encourage you to get started early, as successful students typically have early PRs or working prototypes as part of the application. It is a good idea to simply start contributing via issue discussion and PRs and let a project grow from there; you can take a look at [this list of issues](https://github.com/issues?utf8=✓&q=is%3Aopen+archived%3Afalse+user%3AFluxML+label%3A%22help+wanted%22) for some starter contributions.
+# {{< get_param title >}}
 
 ### CUDA Hacking
 
@@ -20,6 +16,47 @@ Mentors: [Tim Besard](https://github.com/maleadt), [Mike Innes](https://github.c
 Develop a series of reinforcement learning environments, in the spirit of the [OpenAI Gym](https://gym.openai.com). Although we have wrappers for the gym available, it is hard to install (due to the Python dependency) and, since it's written in Python and C code, we can't do more interesting things with it (such as differentiate through the environments). A pure-Julia version that supports a similar API and visualisation options would be valuable to anyone doing RL with Flux.
 
 Mentors: [Dhairya Gandhi](https://github.com/dhairyagandhi96/).
+
+### NLP Tools and Models
+
+Build deep learning models for Natural Language Processing in Julia. [TextAnalysis](https://github.com/juliatext/TextAnalysis.jl)  and [WordTokenizers](https://github.com/JuliaText/WordTokenizers.jl) contains the basic algorithms and data structures to work with textual data in Julia. On top of that base, we want to build modern deep learning models based on recent research. The following tasks can span multiple students and projects.
+
+It is important to note that we want practical, usable solutions to be created, not just research models. This implies that a large part of the effort will need to be in finding and using training data, and testing the models over a wide variety of domains. Pre-trained models must be available to users, who should be able to start using these without supplying their own training data.
+
+* Implement [ELMo](https://allennlp.org/elmo) in Julia
+* Implement [ALBERT](https://ai.googleblog.com/2019/12/albert-lite-bert-for-self-supervised.html) in Julia
+* Implement GPT/GPT-2 in Julia
+* Implement [extractive summarisation based on Transformers](https://arxiv.org/abs/1909.03186)
+* Implement practical models for
+  * Dependency Tree Parsing  
+  * Morphological extractions  
+  * Translations (using Transformers)  
+* Indic language support -- validate and test all models for Indic languages
+  * ULMFiT models for Indic languages
+* Chinese tokenisation and parsing
+
+**Mentors**: [Avik Sengupta](https://github.com/aviks/)
+
+### Automated music generation
+
+Neural network based models can be used for music analysis and music generation (composition). A suite
+of tools in Julia to enable research in this area would be useful. This is a large, complex project that
+is suited for someone with an interest in music and machine learning. This project will need a mechanism
+to read music files (primarily MIDI), a way to synthesise sounds, and finally a model to learn composition.
+All of this is admittedly a lot of work, so the exact boundaries of the project can be flexible, but this can be an
+exciting project if you are interested in both music and machine learning.
+
+**Recommended Skills**: Music notation, some basic music theory, MIDI format, Transformer and LSTM architectures
+
+**Resources**: [Music Transformer](https://magenta.tensorflow.org/music-transformer), [Wave2MIDI2Wave](https://magenta.tensorflow.org/maestro-wave2midi2wave)
+
+**Mentors**: [Avik Sengupta](https://github.com/aviks/)
+
+## Flux.jl
+
+Flux usually takes part in [Google Summer of Code](https://summerofcode.withgoogle.com), as part of the wider Julia organisation. We follow the same [rules and application guidelines](https://julialang.org/soc/ideas-page) as Julia, so please check there for more information on applying. Below are a set of ideas for potential projects (though you are welcome to explore anything you are interested in).
+
+Flux projects are typically very competitive; we encourage you to get started early, as successful students typically have early PRs or working prototypes as part of the application. It is a good idea to simply start contributing via issue discussion and PRs and let a project grow from there; you can take a look at [this list of issues](https://github.com/issues?utf8=✓&q=is%3Aopen+archived%3Afalse+user%3AFluxML+label%3A%22help+wanted%22) for some starter contributions.
 
 ### Port ML Tutorials
 

--- a/content/jsoc/gsoc/hpc.md
+++ b/content/jsoc/gsoc/hpc.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title:  HPC Projects – Summer of Code
+title:  High Performance and Parallel Computing Projects – Summer of Code
 ---
 
 # {{< get_param title >}}
@@ -16,3 +16,31 @@ This project proposes to implement a very simple persistent storage mechanism fo
 Distributed computation frameworks like Hadoop/MapReduce have demonstrated the usefulness of an abstraction layer that takes care of low level concurrency concerns such as atomicity and fine-grained synchronization, thus allowing users to concentrate on task-level decomposition of extremely large problems such as massively distributed text processing. However, the tree-based scatter/gather design of MapReduce limits its usefulness for general purpose data parallelism, and in particular poses significant restrictions on the implementation of iterative algorithms.
 
 This project proposal is to implement a native Julia framework for distributed execution for general purpose data parallelism, using dynamic, runtime-generated general task graphs which are flexible enough to describe multiple classes of parallel algorithms. Students will be expected to weave together native Julia parallelism constructs such as the `ClusterManager` for massively parallel execution, and automate the handling of data dependencies using native Julia `RemoteRefs` as remote data futures and handles. Students will also be encouraged to experiment with novel scheduling algorithms.
+
+## Model Zoo on TPU
+
+Julia has experimental support for executing code on TPUs (https://github.com/JuliaTPU/XLA.jl) TPUs enable training cutting edge machine learning models written using Flux. However, TPUs are not able to execute arbitrary code and thus often require individual attention to fix new patterns in XLA.jl or other packages. Additionally, the performance characteristics of the TPU hardware are quite unlike that of CPU or even GPU and models may thus require TPU-specific adjustments to achieve peak performance. Lastly, the speed of TPUs presents significant challenges to data input pipelines even at single-TPU levels of performance. Having a wide set of models available that are tuned for TPU will aid in finding common abstractions for models independent of hardware.
+
+Mentors: [Keno Fischer](https://github.com/Keno)
+
+## Scientific Integration Benchmarks
+
+A benchmark suite would help us to keep Julia's performance for ML models in shape, as well as revealing opportunities for improvement. Like the model-zoo project, this would involve contributing standard models that exercise common ML use case (images, text etc) and profiling them. The project could extend to include improving performance where possible, or creating a "benchmarking CI" like Julia's own [nanosoldier](https://github.com/JuliaCI/Nanosoldier.jl).
+
+Mentors: [Dhairya Gandhi](https://github.com/dhairyagandhi96/), [Elliot Saba](https://github.com/staticfloat).
+
+## Multi-GPU training
+
+Implement and demonstrate multi-GPU parallelism. One route is to expose communication primitives from NVIDIA's [NCCL](https://developer.nvidia.com/nccl) library and use these to build tooling for model parallelism and distributed training. The project should demonstrate parallel training of a Flux model with benchmarks.
+
+Mentors: [Valentin Churavy](https://github.com/vchuravy), [Tim Besard](https://github.com/maleadt)
+
+## Distributed Training
+
+Add a distributed training API to Flux, possibly inspired by PyTorch's equivalent. Any distributed training algorithm could be used (ideally the foundations make it easy to experiment with different setups), though the easiest is likely to implement an MXNet-like parameter server. It should demonstrate training a Flux model with data distributed over multiple nodes, with benchmarks.
+
+Mentors: [Valentin Churavy](https://github.com/vchuravy), [Tim Besard](https://github.com/maleadt)
+
+## Sparse GPU and ML support
+
+While Julia supports dense GPU arrays well via [CuArrays](https://github.com/JuliaGPU/CUSPARSE.jl), we lack up-to-date wrappers for sparse operations. This project would involve wrapping CUDA's sparse support, with [CUSPARSE.jl](https://github.com/JuliaGPU/CUSPARSE.jl) as a starting point, adding them to CuArrays.jl, and perhaps demonstrating their use via a sparse machine learning model.

--- a/content/jsoc/gsoc/sciml.md
+++ b/content/jsoc/gsoc/sciml.md
@@ -123,3 +123,21 @@ Julia knowledge is preferred but not strictly required.
 **Expected Results**: Efficient and high-quality implementations of adjoints for Zygote.jl over FEniCS.jl functions.
 
 **Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas)
+
+## Multi-Start Optimization Methods
+
+While standard machine learning can be shown to be "safe" for local optimization,
+scientific machine learning can sometimes require the use of globalizing techniques
+to improve the optimization process. Hybrid methods, known as multistart optimization
+methods, glue together a local optimization technique together with a parameter
+search over a large space of possible initial points. The purpose of this project
+would be to take a [MultistartOptimization.jl](https://github.com/tpapp/MultistartOptimization.jl)
+as a starting point and create a fully featured set of multistart optimization
+tools for use with [Optim.jl](https://github.com/JuliaNLSolvers/Optim.jl)
+
+**Recommended Skills**: A basic background in optimization. Having previous
+Julia knowledge is preferred but not strictly required.
+
+**Expected Results**: Efficient and high-quality implementations of multistart optimization methods.
+
+**Mentors**: [Chris Rackauckas](https://github.com/ChrisRackauckas) and [Patrick Kofod Mogensen](https://github.com/pkofod)

--- a/content/jsoc/gsoc/sciml.md
+++ b/content/jsoc/gsoc/sciml.md
@@ -1,81 +1,30 @@
 ---
 layout: page
-title: Scientific Machine Learning
+title: Scientific Machine Learning Projects - Summer of Code
 ---
 
-# Scientific Machine Learning
+# {{< get_param title >}}
 
-### Model Zoo on TPU
-
-Julia has experimental support for executing code on TPUs (https://github.com/JuliaTPU/XLA.jl) TPUs enable training cutting edge machine larning models written using Flux. However, TPUs are not able to execute arbitrary code and thus often require individual attention to fix new patterns in XLA.jl or other packages. Additionally, the performance characteristics of the TPU hardware are quite unlike that of CPU or even GPU and models may thus require TPU-specific adjustments to achieve peak performance. Lastly, the speed of TPUs presents signficant challenges to data input pipelines even at single-TPU levels of performance. Having a wide set of models available that are tuned for TPU will aid in finding common abstractions for models independent of hardware.
-
-Mentors: [Keno Fischer](https://github.com/Keno)
-
-### Benchmarks
-
-A benchmark suite would help us to keep Julia's performance for ML models in shape, as well as revealing opportunities for improvement. Like the model-zoo project, this would involve contributing standard models that exercise common ML use case (images, text etc) and profiling them. The project could extend to include improving performance where possible, or creating a "benchmarking CI" like Julia's own [nanosoldier](https://github.com/JuliaCI/Nanosoldier.jl).
-
-Mentors: [Dhairya Gandhi](https://github.com/dhairyagandhi96/), [Elliot Saba](https://github.com/staticfloat).
-
-### Multi-GPU training
-
-Implement and demonstrate multi-GPU parallelism. One route is to expose communication primitives from NVIDIA's [NCCL](https://developer.nvidia.com/nccl) library and use these to build tooling for model parallelism and distributed training. The project should demonstrate parallel training of a Flux model with benchmarks.
-
-Mentors: [Valentin Churavy](https://github.com/vchuravy), [Tim Besard](https://github.com/maleadt)
-
-### Distributed Training
-
-Add a distributed training API to Flux, possibly inspired by PyTorch's equivalent. Any distributed training algorithm could be used (ideally the foundations make it easy to experiment with different setups), though the easiest is likely to implement an MXNet-like parameter server. It should demonstrate training a Flux model with data distributed over multiple nodes, with benchmarks.
-
-Mentors: [Valentin Churavy](https://github.com/vchuravy), [Tim Besard](https://github.com/maleadt)
-
-### Sparse GPU and ML support
-
-While Julia supports dense GPU arrays well via [CuArrays](https://github.com/JuliaGPU/CUSPARSE.jl), we lack up-to-date wrappers for sparse operations. This project would involve wrapping CUDA's sparse support, with [CUSPARSE.jl](https://github.com/JuliaGPU/CUSPARSE.jl) as a starting point, adding them to CuArrays.jl, and perhaps demonstrating their use via a sparse machine learning model.
-
-### NLP Tools and Models
-
-Build deep learning models for Natural Language Processing in Julia. [TextAnalysis](https://github.com/juliatext/TextAnalysis.jl)  and [WordTokenizers](https://github.com/JuliaText/WordTokenizers.jl) contains the basic algorithms and data structures to work with textual data in Julia. On top of that base, we want to build modern deep learning models based on recent research. The following tasks can span multiple students and projects.
-
-It is important to note that we want practical, usable solutions to be created, not just research models. This implies that a large part of the effort will need to be in finding and using training data, and testing the models over a wide variety of domains. Pre-trained models must be available to users, who should be able to start using these without supplying their own training data.
-
-* Implement [ELMo](https://allennlp.org/elmo) in Julia
-* Implement [ALBERT](https://ai.googleblog.com/2019/12/albert-lite-bert-for-self-supervised.html) in Julia
-* Implement GPT/GPT-2 in Julia
-* Implement [extractive summarisation based on Transformers](https://arxiv.org/abs/1909.03186)
-* Implement practical models for 
-  * Dependency Tree Parsing  
-  * Morphological extractions  
-  * Translations (using Transformers)  
-* Indic language support -- validate and test all models for Indic languages
-  * ULMFiT models for Indic languages
-* Chinese tokenisation and parsing
-
-**Mentors**: [Avik Sengupta](https://github.com/aviks/)
-
-### Automated music generation
-
-Neural network based models can be used for music analysis and music generation (composition). A suite 
-of tools in Julia to enable research in this area would be useful. This is a large, complex project that
-is suited for someone with an interest in music and machine learning. This project will need a mechanism 
-to read music files (primarily MIDI), a way to synthesise sounds, and finally a model to learn composition. 
-All of this is admittedly a lot of work, so the exact boundaries of the project can be flexible, but this can be an 
-exciting project if you are interested in both music and machine learning. 
-
-**Recommended Skills**: Music notation, some basic music theory, MIDI format, Transformer and LSTM architectures
-
-**Resources**: [Music Transformer](https://magenta.tensorflow.org/music-transformer), [Wave2MIDI2Wave](https://magenta.tensorflow.org/maestro-wave2midi2wave)
-
-**Mentors**: [Avik Sengupta](https://github.com/aviks/)
-
-### Neural networks for solving differential equations
+### Physics-Informed Neural Networks (PINNs) and Solving Differential Equations with Deep Learning
 
 Neural networks can be used as a method for efficiently solving difficult partial
-differential equations. Efficient implementations from recent papers are being
+differential equations. Recently this strategy has been dubbed [physics-informed neural networks](https://www.sciencedirect.com/science/article/pii/S0021999118307125)
+and has seen a resurgence because of its efficiency advantages over classical
+deep learning. Efficient implementations from recent papers are being
 explored as part of the [NeuralNetDiffEq.jl](https://github.com/JuliaDiffEq/NeuralNetDiffEq.jl)
 package. The [issue tracker](https://github.com/JuliaDiffEq/NeuralNetDiffEq.jl/issues)
 contains links to papers which would be interesting new neural network based methods to
-implement and benchmark against classical techniques.
+implement and benchmark against classical techniques. Project work in this area
+includes:
+
+- [Improved training strategies](https://github.com/JuliaDiffEq/NeuralNetDiffEq.jl/issues/71) for PINNs.
+- Implementing new neural architectures that impose physical constraints like [divergence-free criteria](https://arxiv.org/pdf/2002.00021.pdf).
+- Demonstrating large-scale problems solved by PINN training.
+- Improving the speed and parallelization of PINN training routines.
+
+This project is good for both software engineers interested in the field of
+scientific machine learning and those students who are interested in perusing
+graduate research in the field.
 
 **Recommended Skills**: Background knowledge in numerical analysis and machine learning.
 
@@ -159,12 +108,12 @@ Scientific machine learning requires mixing scientific computing libraries with 
 [This blog post highlights how the tooling of Julia is fairly advanced in this field](https://www.stochasticlifestyle.com/the-essential-tools-of-scientific-machine-learning-scientific-ml/) compared to alternatives such as Python,
 but one area that has not been completely worked out is integration of automatic differentiation
 with partial differential equations.
-[FEniCS.jl](https://github.com/JuliaDiffEq/FEniCS.jl) is a wrapper to the 
-[FEniCS](https://fenicsproject.org/) project for finite element solutions of partial differential 
+[FEniCS.jl](https://github.com/JuliaDiffEq/FEniCS.jl) is a wrapper to the
+[FEniCS](https://fenicsproject.org/) project for finite element solutions of partial differential
 equations. We would like to augment the Julia wrappers to allow for integration with Julia's
 automatic differentiation libraries like [Zygote.jl](https://github.com/FluxML/Zygote.jl) by
 using [dolfin-adjoint](http://www.dolfin-adjoint.org/en/release/). This would require setting up
-this library for automatic installation for Julia users and writing adjoint passes which utilize 
+this library for automatic installation for Julia users and writing adjoint passes which utilize
 this adjoint builder library. It would result in the first total integration between PDEs and
 neural networks.
 

--- a/content/jsoc/projects.md
+++ b/content/jsoc/projects.md
@@ -10,11 +10,11 @@ This page lists a bunch of project ideas, meant to serve as starting points as y
 We have our project ideas organized roughly into the skillsets required:
 
 * [Turing projects](/jsoc/gsoc/turing/) for probabilistic modelling and probabilistic programming.
-* [Flux projects](/jsoc/gsoc/flux/) for machine learning.
-* [Scientific Machine Learning Projects](/jsoc/gsoc/sciml/)
+* [Machine Learning](/jsoc/gsoc/flux/) for machine learning.
+* [Scientific Machine Learning](/jsoc/gsoc/sciml/)
 * [Compiler](/jsoc/gsoc/compiler/) – work on the Julia compiler's internals to make things better for everyone.
 * [Web Platform](/jsoc/gsoc/wasm/) – work on the Julia wasm backend or other aspects of julia in the browser.
-* [HPC](/jsoc/gsoc/hpc/) – write code that runs on lots of machines, goes really fast, processes lots of data, or all three.
+* [High Performance and Parallel Computing](/jsoc/gsoc/hpc/) – write code that runs on lots of machines, goes really fast, processes lots of data, or all three.
 * [Numerics](/jsoc/gsoc/numerics/) – Challenges for the hard–core number-cruncher, including linear algebra routines and basic mathematical functions.
 * [Science](/jsoc/gsoc/science/) – provide Julia with the ability for scientific research in various fields.
 * [Differential Equations](/jsoc/gsoc/diffeq/) - Numerical methods for high-performance solving of differential equation models.
@@ -23,7 +23,6 @@ We have our project ideas organized roughly into the skillsets required:
 * [General](/jsoc/gsoc/general/) – jack-of-all-trades projects that don't require special skills.
 * [Graphs](/jsoc/gsoc/graphs/) – extend the JuliaGraphs ecosystem with new algorithms and tools.
 * [Graphics](/jsoc/gsoc/graphics/) – projects ranging from low level OpenGL rendering to high level plotting.
-* [MLJ](/jsoc/gsoc/mlj/) -- a Machine Learning Toolbox for Julia. 
+* [MLJ](/jsoc/gsoc/mlj/) -- a Machine Learning Toolbox for Julia.
 * [Tabular Data](/jsoc/gsoc/tables/)
 * [Continuous time signal processing](/jsoc/gsoc/kalmanbucy/)
-


### PR DESCRIPTION
- Proper split of SciML and ML
- Made a subgrouping for Flux in ML
- Updates to a few project descriptions in SciML
- Title of HPC changed to encourage more students to look at it, and moved parallelism-specific projects over to there.