### PR TITLE
RFC: Support tier shuffle: Win32, ARMv7 -= 1, AArch64 += 1

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -250,7 +250,7 @@ The platforms currently supported by Julia are listed below. They are divided in
     <tr>
 
       <td> i686 (32-bit) </td>
-      <td> Tier 1 </td>
+      <td> Tier 2 </td>
     </tr>
     <tr>
       <td rowspan="7"> Linux </td>
@@ -271,12 +271,12 @@ The platforms currently supported by Julia are listed below. They are divided in
     <tr>
 
       <td> ARMv7 (32-bit) </td>
-      <td> Tier 2 </td>
+      <td> Tier 3 </td>
     </tr>
     <tr>
 
       <td> ARMv8 (64-bit) </td>
-      <td> Tier 2 </td>
+      <td> Tier 1 </td>
     </tr>
     <tr>
 


### PR DESCRIPTION
This shuffles a few support tiers:

* 32-bit Windows shifts from tier 1 to tier 2 support. This will allow to continue working on releases even if Win32 is being finicky with some tests. (This is the case for v1.4.0, with Win32 intermittently failing the Distributed tests.)

* AArch64 shifts from tier 2 to tier 1. We have CI that ensures that AArch64 builds and passes tests, and it has been doing so consistently for a while now.

* ARMv7 shifts from tier 2 to 3. We've had a number of issues on ARMv7, which have made producing release binaries quite tricky due to build failures and other issues.