### PR TITLE
Fix some 14 trival spelling mistakes.

### DIFF
--- a/jsoc/gsoc/diffeq.md
+++ b/jsoc/gsoc/diffeq.md
@@ -85,14 +85,14 @@ linear algebra, and the ability (or eagerness to learn) to write fast code.
 
 ## Discretizations of partial differential equations
 
-There are two ways to approach libraires for partial differential equations (PDEs): one can build "toolkits" which enable users to discretize any PDE but require knowledge
+There are two ways to approach libraries for partial differential equations (PDEs): one can build "toolkits" which enable users to discretize any PDE but require knowledge
 of numerical PDE methods, or one can build "full-stop" PDE solvers for specific
 PDEs. There are many different ways solving PDEs could be approached, and here
 are some ideas for potential projects:
 
 @@tight-list
 1. Automated PDE discretization tooling. We want users to describe a PDE in its mathematical form and automate the rest of the solution process. See [this issue for details](https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/469).
-2. Enhancement of existing tools for discretizing PDEs. The finite differencing (FDM) library [DiffEqOperators.jl](https://github.com/JuliaDiffEq/DiffEqOperators.jl) could be enahnced to allow non-uniform grids or composition of operators. The finite element method (FEM) library [FEniCS.jl](https://github.com/JuliaDiffEq/FEniCS.jl) could wrap more of the FEniCS library.
+2. Enhancement of existing tools for discretizing PDEs. The finite differencing (FDM) library [DiffEqOperators.jl](https://github.com/JuliaDiffEq/DiffEqOperators.jl) could be enhanced to allow non-uniform grids or composition of operators. The finite element method (FEM) library [FEniCS.jl](https://github.com/JuliaDiffEq/FEniCS.jl) could wrap more of the FEniCS library.
 3. Full stop solvers of common fluid dynamical equations, such as diffusion-advection-convection equations, or of hyperbolic PDEs such as the Hamilton-Jacobi-Bellman equations would be useful to many users.
 4. Using stochastic differential equation (SDE) solvers to efficiently (and highly parallel) approximate certain PDEs.
 5. Development of ODE solvers for more efficiently solving specific types of PDE discretizations. See the "Native Julia solvers for ordinary differential equations" project.
@@ -128,7 +128,7 @@ analysis.
 
 Parameter identifiability analysis is an analysis that describes whether the
 parameters of a dynamical system can be identified from data or whether they
-are redundent. There are two forms of identifiability analysis: structural
+are redundant. There are two forms of identifiability analysis: structural
 and practical. Structural identifiability analysis relates changes in the
 solution of the ODE directly to other parameters, showcasing that it is
 impossible to distinguish between parameter A being higher and parameter B

--- a/jsoc/gsoc/images.md
+++ b/jsoc/gsoc/images.md
@@ -29,7 +29,7 @@ OpenCV is one of the pre-eminent image-processing frameworks, and there are two 
 
 ## Contributions to a Stereo Matching Package
 
-When two images are taken of a scene with a calibrated stereo rig it is possible to construct a three-dimensional model of the scene provided that one can determine the coordinates of corresponding points in the two images. The task of determining the coordinates of corresponding points is frequenly called *stereo matching* or *disparity estimation*. Numerous algorithms for this task have been proposed over the years and new ones continue to be developed.
+When two images are taken of a scene with a calibrated stereo rig it is possible to construct a three-dimensional model of the scene provided that one can determine the coordinates of corresponding points in the two images. The task of determining the coordinates of corresponding points is frequently called *stereo matching* or *disparity estimation*. Numerous algorithms for this task have been proposed over the years and new ones continue to be developed.
 
 This project will implement several stereo matching algorithms. Emphasis will be placed on *efficient* implementations which leverage all of Julia's features for writing fast code.
 

--- a/jsoc/gsoc/numerics.md
+++ b/jsoc/gsoc/numerics.md
@@ -35,7 +35,7 @@ This project proposal is for implementing native Julia algorithms involving effi
 
 Modern data-intensive computations, such as Google's PageRank algorithm, can often be cast as operations involving sparse matrices of extremely large nominal dimensions. Unlike dense matrices, which decompose naturally into many homogeneous tiles, efficient algorithms for working with sparse matrices must be fully cognizant of the sparsity pattern of specific matrices at hand, which oftentimes reduce to efficiently computing partitions of extremely large graphs.
 
-This project proposal is for implementing native Julia algorithms for massively parallel sparse linear algebra routines. Unlike the project above for dense linear algebra, efficient parallel algorithms for sparse linear algebra are comparatively less well studied and understood. Students will be expected to implement several algorithms for common tasks such as linear solvers or computing eigenvectors, and benchmark the performance of these algrithms on various real world applications.
+This project proposal is for implementing native Julia algorithms for massively parallel sparse linear algebra routines. Unlike the project above for dense linear algebra, efficient parallel algorithms for sparse linear algebra are comparatively less well studied and understood. Students will be expected to implement several algorithms for common tasks such as linear solvers or computing eigenvectors, and benchmark the performance of these algorithms on various real world applications.
 
 **Recommended Skills**: Strong linear algebra background. Familiarity with numerical linear algebra, especially sparse matrices, and some background knowledge in parallel computing.
 

--- a/jsoc/gsoc/science.md
+++ b/jsoc/gsoc/science.md
@@ -1,7 +1,7 @@
 
 # Scientific Projects – Summer of Code
 
-## Quantum Computation: Simualation of Noisy Circuits
+## Quantum Computation: Simulation of Noisy Circuits
 
 [Noisy Intermediate-Scale Quantum (NISQ) technology will be available in the near future.](https://arxiv.org/abs/1801.00862) However, it would be much more convenient if we could test our algorithm with noise and simulate our quantum algorithm on noisy circuits to explore their stability, efficiency. To assist the research of NISQ, enhance the quantum circuit simulator in Julia [Yao.jl](https://github.com/QuantumBFS/Yao.jl) with noisy circuit simulation would be quite useful. We are planning to implement the algorithm in a recent paper as our SoC project: [Efficient classical simulation of noisy quantum computation](https://arxiv.org/pdf/1810.03176.pdf).
 

--- a/jsoc/gsoc/turing.md
+++ b/jsoc/gsoc/turing.md
@@ -37,7 +37,7 @@ Julia's GPU tooling is generally quite good, but currently Turing is not able to
 **Expected output:** A set of Distributions.jl objects where `logpdf` calls can be easily run through a GPU.
 
 ## GPnet extensions
-One of Turing's sattelite packages, [GPnet](https://github.com/TuringLang/GPnet.jl), is designed to provide a comprehensive suite of Gaussian process tools. See [this issue](https://github.com/TuringLang/GPnet.jl/issues/2) for potential tasks -- there's a lot of interesting stuff going on with GPs, and this task in particular may have some creative freedom to it.
+One of Turing's satellite packages, [GPnet](https://github.com/TuringLang/GPnet.jl), is designed to provide a comprehensive suite of Gaussian process tools. See [this issue](https://github.com/TuringLang/GPnet.jl/issues/2) for potential tasks -- there's a lot of interesting stuff going on with GPs, and this task in particular may have some creative freedom to it.
 
 **Recommended skills:** Gaussian processes. Some Python required, as GPnet uses PyCall.
 
@@ -45,7 +45,7 @@ One of Turing's sattelite packages, [GPnet](https://github.com/TuringLang/GPnet.
 
 ## Model comparison tools
 
-Turing and its sattelite packages do not currently provide a comprehensive suite of model comparison tools, a critical tool for the applied statistician. A student who worked on this project would implement various model comparison tools like [LOO and WAIC](https://mc-stan.org/loo/), among others.
+Turing and its satellite packages do not currently provide a comprehensive suite of model comparison tools, a critical tool for the applied statistician. A student who worked on this project would implement various model comparison tools like [LOO and WAIC](https://mc-stan.org/loo/), among others.
 
 **Recommended skills:** General statistics. Bayesian inference and model comparison. Some Julia programming.
 
@@ -63,6 +63,6 @@ Turing and its sattelite packages do not currently provide a comprehensive suite
 
 Small, fixed-size vectors and matrices are fairly common in Turing models. This means that sampling in Turing can probably benefit from using statically sized vectors and matrices from StaticArrays.jl instead of normal, dynamic Julia arrays. Beside the often superior performance of small static vectors and matrices, static arrays are also automatically compatible with the GPU stack in Julia. Currently, the main obstacle to using StaticArrays.jl is that distributions in Distributions.jl are not compatible with StaticArrays. A GSoC student would adapt the multivariate and matrix-variate distributions as well as the univariate distribution with vector parameters in Distributions.jl to make a spin-off package called StaticDistributions.jl. The student would then benchmark StaticDistributions.jl against Distributions.jl and showcase an example of using StaticDistributions.jl together with CuArrays.jl and/or CUDAnative.jl for GPU-acceleration.
 
-**Recommended skills:** An understanding of generated functions in Julia. Some knowledge of random number generators and probablity distributions. An interest in performance optimization and micro-optimization as well as general-purpose GPU programming.
+**Recommended skills:** An understanding of generated functions in Julia. Some knowledge of random number generators and probability distributions. An interest in performance optimization and micro-optimization as well as general-purpose GPU programming.
 
 **Expected output:** A package StaticDistributions.jl containing implementations of non-allocating multivariate and matrix-variate distributions with vectorized logpdf support, a benchmarking of StaticDistributions.jl against Distributions.jl, and tutorials on how to use StaticDistributions together with CuArrays and the Julia GPU stack.

--- a/jsoc/gsoc/wasm.md
+++ b/jsoc/gsoc/wasm.md
@@ -13,7 +13,7 @@ Because Julia relies on an asynchronous task runtime and WebAssembly currently l
 
 ## Wasm threading
 
-WebAssembly is in the process of standardizing [threads](https://github.com/WebAssembly/threads). Simultaneously, work is ongoing to to introduce a new threading runtime in julia (see [#22631](https://github.com/JuliaLang/julia/pull/22631) and replated PRs). This project would investigate enabling threading support for Julia on the WebAssembly platform, implenting runtime parallel primitives on the web assembly platform and ensuring that high level threading constructs are correctly mapped to the underlying platform. Please note that both the WebAssembly and julia threading infrastructure is still in active development and may continue to change over the duration of the project. An informed understanding of the state of these projects is a definite pre-requisite for this project.
+WebAssembly is in the process of standardizing [threads](https://github.com/WebAssembly/threads). Simultaneously, work is ongoing to to introduce a new threading runtime in julia (see [#22631](https://github.com/JuliaLang/julia/pull/22631) and replated PRs). This project would investigate enabling threading support for Julia on the WebAssembly platform, implementing runtime parallel primitives on the web assembly platform and ensuring that high level threading constructs are correctly mapped to the underlying platform. Please note that both the WebAssembly and julia threading infrastructure is still in active development and may continue to change over the duration of the project. An informed understanding of the state of these projects is a definite pre-requisite for this project.
 
 **Recommended Skills**: Experience with C and multi-threaded programming.
 
@@ -37,19 +37,19 @@ Several Julia libraries (e.g. WebIO.jl, Escher.jl) provide input and output capa
 
 ## Iodide notebook integration
 
-Experimental support exists for running Julia/wasm inside [Iodide](https://github.com/iodide-project/iodide) notebooks. There are a number of possible improvements to this integration, such as improving the quality of output and allowing interactive exploration of Julia objects from the iodide frontend. In addition, iodide notebooks should have support for specifying Julia manifest files in order to allow reproducability in the face of changing package versions.
+Experimental support exists for running Julia/wasm inside [Iodide](https://github.com/iodide-project/iodide) notebooks. There are a number of possible improvements to this integration, such as improving the quality of output and allowing interactive exploration of Julia objects from the iodide frontend. In addition, iodide notebooks should have support for specifying Julia manifest files in order to allow reproducibility in the face of changing package versions.
 
 **Recommended Skills**: Experience with JavaScript.
 
 ## Native dependencies for the web
 
-The Julia project uses [BinaryBuilder](https://github.com/JuliaPackaging/BinaryBuilder.jl) to provide binaries of native dependencies of julia packages. Experiemental support exists to extend this support to the wasm platform, but few packages have been ported. This project would consist of attempting to port a significant fraction of the binary dependencies of the julia ecosystem to the web platform by improving the toolchain support in BinaryBuilder or (if necessary), porting upstream packages to fix assumptions not applicable on the wasm platform.
+The Julia project uses [BinaryBuilder](https://github.com/JuliaPackaging/BinaryBuilder.jl) to provide binaries of native dependencies of julia packages. Experimental support exists to extend this support to the wasm platform, but few packages have been ported. This project would consist of attempting to port a significant fraction of the binary dependencies of the julia ecosystem to the web platform by improving the toolchain support in BinaryBuilder or (if necessary), porting upstream packages to fix assumptions not applicable on the wasm platform.
 
-**Recommended Skills**: Experience with building native libraries in Unix enivronments.
+**Recommended Skills**: Experience with building native libraries in Unix environments.
 
 ## Distributed computing with untrusted parties
 
-The Distributed computing abstractions in julia provide convenient abstraction for implementing programs that span many communicating julia processes on different machines. However, the existing abstractions generally asssume that all communicating processes are part of the same trust domain (e.g. they allow messages to execute arbitrary code on the remote). With some of the nodes potentially running in the web browser (or multiple browser nodes being part of the same distributed computing cluster via WebRPC), this assumption no longer holds true and new interfaces need to be designed to support multiple trust domains without overly restricting usability.
+The Distributed computing abstractions in julia provide convenient abstraction for implementing programs that span many communicating julia processes on different machines. However, the existing abstractions generally assume that all communicating processes are part of the same trust domain (e.g. they allow messages to execute arbitrary code on the remote). With some of the nodes potentially running in the web browser (or multiple browser nodes being part of the same distributed computing cluster via WebRPC), this assumption no longer holds true and new interfaces need to be designed to support multiple trust domains without overly restricting usability.
 
 **Recommended Skills**: Experience with distributed computing and writing libraries in Julia.
 


### PR DESCRIPTION
As my issue says,

By accident, I see a spelling mistake in **https://julialang.org/jsoc/gsoc/diffeq**,
then I check the spelling mistakes in https://julialang.org/jsoc/projects/ and all subpages, and find out mistakes as following.
Maybe these should be fixed.
In **https://julialang.org/jsoc/projects/**,
1. The word '_skillsets_' should be spelled into '_skill sets_'; 
In **https://julialang.org/jsoc/gsoc/flux/**, **no mistakes**.
In **https://julialang.org/jsoc/gsoc/sciml/**, **no mistakes**.
In **https://julialang.org/jsoc/gsoc/compiler/**, **no mistakes**.
In **https://julialang.org/jsoc/gsoc/wasm/**,
2. The word '_implenting_' should be spelled into '_implementing_';
3. The word '_reproducability_' should be spelled into '_reproducibility_';
4. The word '_Experiemental_' should be spelled into '_Experimental_';
5. The word '_enivronments_' should be spelled into '_environments_';
6. The word '_asssume_' should be spelled into '_assume_';
In **https://julialang.org/jsoc/gsoc/hpc/**, **no mistakes**;
In **https://julialang.org/jsoc/gsoc/numerics/**,
7. The word '_algrithms_' should be spelled into '_algorithms_';
In **https://julialang.org/jsoc/gsoc/turing/**,
8. The word '_sattelite_' may be spelled wrongly; ( should it be 'satellite' ?)
9. The word '_probablity_' should be spelled into '_probability_';
In **https://julialang.org/jsoc/gsoc/science/**,
10. The word '_Simualation_' should be spelled into '_Simulation_';
In **https://julialang.org/jsoc/gsoc/tooling/**, **no mistakes**;
In **https://julialang.org/jsoc/gsoc/images/**, 
11. The word '_frequenly_' should be spelled into '_frequently_';
In **https://julialang.org/jsoc/gsoc/general/**, **no mistakes**;
In **https://julialang.org/jsoc/gsoc/graphs/**, **no mistakes**;
In **https://julialang.org/jsoc/gsoc/graphics/**,  **no mistakes**;
In **https://julialang.org/jsoc/gsoc/mlj/**, **no mistakes**;
In **https://julialang.org/jsoc/gsoc/tables/**, **no mistakes**;
In **https://julialang.org/jsoc/gsoc/diffeq**,
12. The word '_libraires_' in "There are two ways to approach libraires" should be spelled into '_libraries_';
13. The word '_enahnced_' in "DiffEqOperators.jl could be enahnced to allow non-uniform grids or composition of operators." should be spelled into '_enhanced_';
14. The word '_redundent_' in "Parameter identifiability analysis is an analysis that describes whether the parameters of a dynamical system can be identified from data or whether they are redundent." should be spelled into '_redundant_';
To avoid these mistakes is easy, just do an spelling examination is ok.
I don't know where to state these so state here. And maybe this issue too boring.

----------------
Now create pull request.