### PR TITLE
closes #677: adds templating for downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Start by installing Franklin: in Julia,
 julia> using Pkg; Pkg.add("Franklin")
 ```
 
+(Note: _if you already have Franklin, make sure to update it to the latest version before proceeding_).
+
 then, clone the repository, `cd` to  it and do
 
 ```

--- a/config.md
+++ b/config.md
@@ -8,9 +8,11 @@
 @def author = ""
 
 <!-- Templating of the Downloads -->
-@def stable_release = v"1.4.0"
+@def stable_release = "1.4.0"
+@def stable_release_short = "1.4"
 @def stable_release_date = "March 21, 2020"
-@def lts_release = v"1.0.5"
+@def lts_release = "1.0.5"
+@def lts_release_short = "1.0"
 @def lts_release_date = "Sep 9, 2019"
 
 <!-- @def upcoming_release  -->

--- a/config.md
+++ b/config.md
@@ -23,4 +23,4 @@ in `downloads/index.md` will not be shown.
 @def upcoming_release = "1.4.0-rc2"
 @def upcoming_release_short = "1.4"
 @def upcoming_release_date = "February 25, 2020"
- -->
+-->

--- a/config.md
+++ b/config.md
@@ -6,3 +6,11 @@
 @def hasmath = false <!-- by default pages don't have maths or code -->
 @def hascode = false
 @def author = ""
+
+<!-- Templating of the Downloads -->
+@def stable_release = v"1.4.0"
+@def stable_release_date = "March 21, 2020"
+@def lts_release = v"1.0.5"
+@def lts_release_date = "Sep 9, 2019"
+
+<!-- @def upcoming_release  -->

--- a/config.md
+++ b/config.md
@@ -15,4 +15,12 @@
 @def lts_release_short = "1.0"
 @def lts_release_date = "Sep 9, 2019"
 
-<!-- @def upcoming_release  -->
+<!--
+If the following lines are commented, the "upcoming release" section
+in `downloads/index.md` will not be shown.
+-->
+<!--
+@def upcoming_release = "1.4.0-rc2"
+@def upcoming_release_short = "1.4"
+@def upcoming_release_date = "February 25, 2020"
+ -->

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -21,9 +21,9 @@ Different OSes and architectures have varying [tiers of support](/downloads/#cur
 @@
 
 
-## Current stable release: v1.4.0 (March 21, 2020)
+## Current stable release: v{{stable_release}} ({{stable_release_date}})
 
-Checksums for this release are available in both [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-1.4.0.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-1.4.0.sha256) formats.
+Checksums for this release are available in both [MD5](https://julialang-s3.julialang.org/bin/checksums/{{stable_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/{{stable_release}}.sha256) formats.
 
 @@row @@col-12
 ~~~
@@ -31,43 +31,43 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
   <tbody>
     <tr>
       <th> Windows (.exe) <a href="/downloads/platform/#windows">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.4/julia-1.4.0-win32.exe">32-bit</a> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.4/julia-1.4.0-win64.exe">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.4/{{stable_release}}-win32.exe">32-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.4/{{stable_release}}-win64.exe">64-bit</a> </td>
     </tr>
     <tr>
       <th> macOS 10.8+ (.dmg) <a href="/downloads/platform/#macos">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.4/julia-1.4.0-mac64.dmg">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.4/{{stable_release}}-mac64.dmg">64-bit</a> </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.4/julia-1.4.0-linux-i686.tar.gz">32-bit</a>
-        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.4/julia-1.4.0-linux-i686.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.4/{{stable_release}}-linux-i686.tar.gz">32-bit</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.4/{{stable_release}}-linux-i686.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.0-linux-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.0-linux-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.4/{{stable_release}}-linux-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.4/{{stable_release}}-linux-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for ARM <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.4/julia-1.4.0-linux-aarch64.tar.gz">64-bit (AArch64)</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.4/julia-1.4.0-linux-aarch64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.4/{{stable_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.4/{{stable_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic FreeBSD Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.4/julia-1.4.0-freebsd-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.4/julia-1.4.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.4/{{stable_release}}-freebsd-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.4/{{stable_release}}-freebsd-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Source </th>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/julia-1.4.0.tar.gz">Tarball</a>
-            (<a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/julia-1.4.0.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}.tar.gz">Tarball</a>
+            (<a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/julia-1.4.0-full.tar.gz">Tarball with dependencies</a>
-        (<a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/julia-1.4.0-full.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}-full.tar.gz">Tarball with dependencies</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}-full.tar.gz.asc">GPG</a>)
       </td>
       <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.4.0">GitHub</a> </td>
     </tr>
@@ -78,9 +78,9 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
 
 
 
-## Long-term support (LTS) release: v1.0.5 (Sep 9, 2019)
+## Long-term support (LTS) release: v{{lts_release}} ({{lts_release_date}})
 
-Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-1.0.5.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-1.0.5.sha256) formats.
+Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/{{lts_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/{{lts_release}}.sha256) formats.
 
 @@row @@col-12
 ~~~
@@ -88,46 +88,46 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
   <tbody>
     <tr>
       <th> Windows (.exe) <a href="/downloads/platform/#windows">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0.5-win32.exe">32-bit</a> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.5-win64.exe">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.0/{{lts_release}}-win32.exe">32-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.0/{{lts_release}}-win64.exe">64-bit</a> </td>
     </tr>
     <tr>
       <th> macOS 10.8+ (.dmg) <a href="/downloads/platform/#macos">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.0/julia-1.0.5-mac64.dmg">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.0/{{lts_release}}-mac64.dmg">64-bit</a> </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.5-linux-i686.tar.gz">32-bit</a>
-        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/julia-1.0.5-linux-i686.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/{{lts_release}}-linux-i686.tar.gz">32-bit</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/{{lts_release}}-linux-i686.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.5-linux-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.5-linux-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/{{lts_release}}-linux-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/{{lts_release}}-linux-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for ARM <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/julia-1.0.5-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
-        (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/julia-1.0.5-linux-armv7l.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/{{lts_release}}-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/{{lts_release}}-linux-armv7l.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.0/julia-1.0.5-linux-aarch64.tar.gz">64-bit (AArch64)</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.0/julia-1.0.5-linux-aarch64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.0/{{lts_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.0/{{lts_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic FreeBSD Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.5-freebsd-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/julia-1.0.5-freebsd-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/{{lts_release}}-freebsd-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/{{lts_release}}-freebsd-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Source </th>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/julia-1.0.5.tar.gz">Tarball</a>
-            (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/julia-1.0.5.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}.tar.gz">Tarball</a>
+            (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/julia-1.0.5-full.tar.gz">Tarball with dependencies</a>
-        (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/julia-1.0.5-full.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}-full.tar.gz">Tarball with dependencies</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}-full.tar.gz.asc">GPG</a>)
       </td>
       <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.0.5">GitHub</a> </td>
     </tr>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -23,7 +23,7 @@ Different OSes and architectures have varying [tiers of support](/downloads/#cur
 
 ## Current stable release: v{{stable_release}} ({{stable_release_date}})
 
-Checksums for this release are available in both [MD5](https://julialang-s3.julialang.org/bin/checksums/{{stable_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/{{stable_release}}.sha256) formats.
+Checksums for this release are available in both [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{stable_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{stable_release}}.sha256) formats.
 
 @@row @@col-12
 ~~~
@@ -31,45 +31,45 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
   <tbody>
     <tr>
       <th> Windows (.exe) <a href="/downloads/platform/#windows">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.4/{{stable_release}}-win32.exe">32-bit</a> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.4/{{stable_release}}-win64.exe">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/{{stable_release_short}}/julia-{{stable_release}}-win32.exe">32-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/{{stable_release_short}}/julia-{{stable_release}}-win64.exe">64-bit</a> </td>
     </tr>
     <tr>
       <th> macOS 10.8+ (.dmg) <a href="/downloads/platform/#macos">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.4/{{stable_release}}-mac64.dmg">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/{{stable_release_short}}/julia-{{stable_release}}-mac64.dmg">64-bit</a> </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.4/{{stable_release}}-linux-i686.tar.gz">32-bit</a>
-        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.4/{{stable_release}}-linux-i686.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/{{stable_release_short}}/julia-{{stable_release}}-linux-i686.tar.gz">32-bit</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/{{stable_release_short}}/julia-{{stable_release}}-linux-i686.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.4/{{stable_release}}-linux-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.4/{{stable_release}}-linux-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{stable_release_short}}/julia-{{stable_release}}-linux-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{stable_release_short}}/julia-{{stable_release}}-linux-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for ARM <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.4/{{stable_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.4/{{stable_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{stable_release_short}}/julia-{{stable_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{stable_release_short}}/julia-{{stable_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic FreeBSD Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.4/{{stable_release}}-freebsd-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.4/{{stable_release}}-freebsd-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{stable_release_short}}/julia-{{stable_release}}-freebsd-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{stable_release_short}}/julia-{{stable_release}}-freebsd-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Source </th>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}.tar.gz">Tarball</a>
-            (<a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{stable_release}}/julia-{{stable_release}}.tar.gz">Tarball</a>
+            (<a href="https://github.com/JuliaLang/julia/releases/download/v{{stable_release}}/julia-{{stable_release}}.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}-full.tar.gz">Tarball with dependencies</a>
-        (<a href="https://github.com/JuliaLang/julia/releases/download/v1.4.0/{{stable_release}}-full.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{stable_release}}/julia-{{stable_release}}-full.tar.gz">Tarball with dependencies</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{stable_release}}/julia-{{stable_release}}-full.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.4.0">GitHub</a> </td>
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v{{stable_release}}">GitHub</a> </td>
     </tr>
   </tbody>
 </table>
@@ -80,7 +80,7 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
 
 ## Long-term support (LTS) release: v{{lts_release}} ({{lts_release_date}})
 
-Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/{{lts_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/{{lts_release}}.sha256) formats.
+Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.sha256) formats.
 
 @@row @@col-12
 ~~~
@@ -88,48 +88,48 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
   <tbody>
     <tr>
       <th> Windows (.exe) <a href="/downloads/platform/#windows">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.0/{{lts_release}}-win32.exe">32-bit</a> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.0/{{lts_release}}-win64.exe">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/{{lts_release_short}}/julia-{{lts_release}}-win32.exe">32-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/{{lts_release_short}}/julia-{{lts_release}}-win64.exe">64-bit</a> </td>
     </tr>
     <tr>
       <th> macOS 10.8+ (.dmg) <a href="/downloads/platform/#macos">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.0/{{lts_release}}-mac64.dmg">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/{{lts_release_short}}/julia-{{lts_release}}-mac64.dmg">64-bit</a> </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/{{lts_release}}-linux-i686.tar.gz">32-bit</a>
-        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.0/{{lts_release}}-linux-i686.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/{{lts_release_short}}/julia-{{lts_release}}-linux-i686.tar.gz">32-bit</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/{{lts_release_short}}/julia-{{lts_release}}-linux-i686.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/{{lts_release}}-linux-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.0/{{lts_release}}-linux-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{lts_release_short}}/julia-{{lts_release}}-linux-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{lts_release_short}}/julia-{{lts_release}}-linux-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic Linux Binaries for ARM <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/{{lts_release}}-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
-        (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.0/{{lts_release}}-linux-armv7l.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{lts_release_short}}/julia-{{lts_release}}-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{lts_release_short}}/julia-{{lts_release}}-linux-armv7l.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.0/{{lts_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
-          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.0/{{lts_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{lts_release_short}}/julia-{{lts_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+          (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{lts_release_short}}/julia-{{lts_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Generic FreeBSD Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/{{lts_release}}-freebsd-x86_64.tar.gz">64-bit</a>
-          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.0/{{lts_release}}-freebsd-x86_64.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{lts_release_short}}/julia-{{lts_release}}-freebsd-x86_64.tar.gz">64-bit</a>
+          (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{lts_release_short}}/julia-{{lts_release}}-freebsd-x86_64.tar.gz.asc">GPG</a>)
       </td>
     </tr>
     <tr>
       <th> Source </th>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}.tar.gz">Tarball</a>
-            (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{lts_release}}/julia-{{lts_release}}.tar.gz">Tarball</a>
+            (<a href="https://github.com/JuliaLang/julia/releases/download/v{{lts_release}}/julia-{{lts_release}}.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}-full.tar.gz">Tarball with dependencies</a>
-        (<a href="https://github.com/JuliaLang/julia/releases/download/v1.0.5/{{lts_release}}-full.tar.gz.asc">GPG</a>)
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{lts_release}}/julia-{{lts_release}}-full.tar.gz">Tarball with dependencies</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{lts_release}}/julia-{{lts_release}}-full.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.0.5">GitHub</a> </td>
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v{{lts_release}}">GitHub</a> </td>
     </tr>
   </tbody>
 </table>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -140,7 +140,7 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
 
 ## Upcoming release: v{{upcoming_release}} ({{upcoming_release_date}})
 
- We're currently testing release candidates for Julia v1.4.0, an upcoming minor release in the 1.x series of releases. We encourage developers and interested users to try it out and report any issues they encounter. As a prerelease, it should not be considered production-ready; it's intended to give users a chance to try out 1.4 with their code before the full release.
+ We're currently testing release candidates for Julia v{{upcoming_release_short}}, an upcoming minor release in the 1.x series of releases. We encourage developers and interested users to try it out and report any issues they encounter. As a prerelease, it should not be considered production-ready; it's intended to give users a chance to try out {{upcoming_release_short}} with their code before the full release.
 
 Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{upcoming_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{upcoming_release}}.sha256) formats.
 
@@ -191,7 +191,7 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
       <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz">Tarball with dependencies</a>
         (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.4.0-rc2">GitHub</a> </td>
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v{{upcoming_release}}">GitHub</a> </td>
     </tr>
   </tbody>
 </table>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -136,6 +136,70 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
 ~~~
 @@ @@
 
+{{ifdef upcoming_release}}
+
+## Upcoming release: v{{upcoming_release}} ({{upcoming_release_date}})
+
+ We're currently testing release candidates for Julia v1.4.0, an upcoming minor release in the 1.x series of releases. We encourage developers and interested users to try it out and report any issues they encounter. As a prerelease, it should not be considered production-ready; it's intended to give users a chance to try out 1.4 with their code before the full release.
+
+Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{upcoming_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{upcoming_release}}.sha256) formats.
+
+@@row @@col-12
+~~~
+<table class="downloads table table-hover  table-bordered">
+  <tbody>
+    <tr>
+      <th> Windows Self-Extracting Archive (.exe) <a href="/downloads/platform/#windows">[help]</a></th>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-win32.exe">32-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-win64.exe">64-bit</a> </td>
+    </tr>
+    <tr>
+      <th> macOS 10.8+ Package (.dmg) <a href="/downloads/platform/#macos">[help]</a></th>
+      <td colspan="3"> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-mac64.dmg">64-bit</a> </td>
+    </tr>
+    <tr>
+      <th> Generic Linux Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-i686.tar.gz">32-bit</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-i686.tar.gz.asc">GPG</a>)
+      </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz">64-bit</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz.asc">GPG</a>)
+      </td>
+    </tr>
+    <tr>
+      <th> Generic Linux Binaries for ARM <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
+      <td colspan="3"> Coming soon <!--<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+                                       (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-armv7l.tar.gz.asc">GPG</a>) -->
+      </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
+        (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
+      </td>
+    </tr>
+    <tr>
+      <th> Generic FreeBSD Binaries for x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
+      <td colspan="3"> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-freebsd-x86_64.tar.gz">64-bit</a>
+        (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-freebsd-x86_64.tar.gz.asc">GPG</a>)
+      </td>
+    </tr>
+    <tr>
+      <th> Source </th>
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz">Tarball</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz.asc">GPG</a>)
+      </td>
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz">Tarball with dependencies</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz.asc">GPG</a>)
+      </td>
+      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.4.0-rc2">GitHub</a> </td>
+    </tr>
+  </tbody>
+</table>
+~~~
+@@ @@
+
+{{end}} <!-- upcoming_release -->
+
 
 ## Older Releases
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <div class="row">
           <div class="col"></div>
           <div class="col-lg-auto col-md-auto col-sm-auto">
-            <a class="btn btn-success btn-lg btn-block" href="/downloads/" role="button">Download v1.4</a>
+            <a class="btn btn-success btn-lg btn-block" href="/downloads/" role="button">Download v{{stable_release}}</a>
           <br>
           </div>
           <div class="col-lg-auto col-md-auto col-sm-auto docs">

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <div class="row">
           <div class="col"></div>
           <div class="col-lg-auto col-md-auto col-sm-auto">
-            <a class="btn btn-success btn-lg btn-block" href="/downloads/" role="button">Download v{{stable_release}}</a>
+            <a class="btn btn-success btn-lg btn-block" href="/downloads/" role="button">Download v{{stable_release_short}}</a>
           <br>
           </div>
           <div class="col-lg-auto col-md-auto col-sm-auto docs">


### PR DESCRIPTION
**Note**: this requires Franklin >= 0.6.11. 

In the file `config.md` there is now:

```
@def stable_release = "1.4.0"
@def stable_release_short = "1.4"
@def stable_release_date = "March 21, 2020"
@def lts_release = "1.0.5"
@def lts_release_short = "1.0"
@def lts_release_date = "Sep 9, 2019"
```

On the front page and download page there are `{{stable_release}}` and similar which do the insertion, for instance:

**`index.html`** (front page)
```html
<a class="btn btn-success btn-lg btn-block" href="/downloads/" role="button">Download v{{stable_release_short}}</a>
```

**`downloads/index.md`** (main downloads page)

```
## Current stable release: v{{stable_release}} ({{stable_release_date}})
```

and in the table:

```html
<td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/{{stable_release_short}}/julia-{{stable_release}}-win32.exe">32-bit</a> </td>
```

I'll test all links first then will merge

cc @ViralBShah 