### PR TITLE
Document limitation for pre-Bulldozer AMD CPUs

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -86,6 +86,7 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
 ~~~
 
 Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.sha256) formats.
+Some very old (AMD) CPUs continue to work on (unsupported) Julia 1.3.1, and older versions including Julia LTS.
 
 @@row @@col-12
 ~~~


### PR DESCRIPTION
[skip ci]

https://github.com/JuliaLang/julia/issues/35215#issuecomment-616523407

In short, I would additionally suggest 1.3 as LTS, unless 1.4 or newer can be compiled to work (and published here) on same CPUs. See more in the comment, on two possible LTS versions.

[I'm closing since no interest.]