### PR TITLE
Hyphenation

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
       <!-- 2 -->
       <div class="col-lg-4 col-md-6 feature">
         <h3>Dynamic</h3>
-        <p>Julia is <a href="https://docs.julialang.org/en/v1/manual/types/">dynamically-typed</a>, feels like a scripting language, and has good support for <a href="https://docs.julialang.org/en/v1/stdlib/REPL/">interactive</a> use.</p>
+        <p>Julia is <a href="https://docs.julialang.org/en/v1/manual/types/">dynamically typed</a>, feels like a scripting language, and has good support for <a href="https://docs.julialang.org/en/v1/stdlib/REPL/">interactive</a> use.</p>
       </div>
       <!-- 3 -->
       <div class="col-lg-4 col-md-6 feature">

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
       <!-- 5 -->
       <div class="col-lg-4 col-md-6 feature">
         <h3>Easy to use</h3>
-        <p>Julia has high level syntax, making it an accessible language for programmers from any background or experience level. <a href="https://github.com/JuliaLang/Microbenchmarks/blob/master/perf.jl">Browse the Julia microbenchmarks</a> to get a feel for the language.</p>
+        <p>Julia has high-level syntax, making it an accessible language for programmers from any background or experience level. <a href="https://github.com/JuliaLang/Microbenchmarks/blob/master/perf.jl">Browse the Julia microbenchmarks</a> to get a feel for the language.</p>
       </div>
       <!-- 6 -->
       <div class="col-lg-4 col-md-6 feature">


### PR DESCRIPTION
Hyphens between adjectives change the precedence of parsing, in this case from `high (level syntax)` to `(high level) syntax`.

They also aren't used/required for straight-up adjectives as in "Julia is dynamically-typed" (also, hyphens aren't usually used with adverbs ending in "ly" because they bind tightly to adjectives by default :) )