### PR TITLE
bringing automath/code back (patched Franklin)

### DIFF
--- a/blog/2019/01/fluxdiffeq.md
+++ b/blog/2019/01/fluxdiffeq.md
@@ -3,8 +3,6 @@
 @def published = "18 January 2019"
 @def title = "DiffEqFlux.jl – A Julia Library for Neural Differential Equations"
 @def authors = """Chris Rackauckas, Mike Innes, Yingbo Ma, Jesse Bettencourt, Lyndon White, Vaibhav Dixit"""  
-@def hascode = true
-@def hasmath = true
 
 Translations: [Traditional Chinese](/blog/2019/04/fluxdiffeq-zh_tw/]Traditional Chinese)
 

--- a/config.md
+++ b/config.md
@@ -6,11 +6,7 @@
 
 <!-- NOTE: don't change what's below -->
 @def div_content = "container" <!-- instead of franklin-content -->
-@def hasmath = false <!-- by default pages don't have maths or code -->
-@def hascode = false
 @def author = ""
-@def automath = false
-@def autocode = false
 
 <!-- Templating of the Downloads -->
 @def stable_release = "1.4.1"


### PR DESCRIPTION
this was in before, then removed bc there  was an issue noticed by Chris, now this is fixed so bringing it back.

It allows people who would write blog posts to forget  adding `hascode=true` or `hasmath=true` and let Franklin figure it out.

https://julialang.netlify.com