### PR TITLE
[draft] adding functionality for meta information for blog pages

### DIFF
--- a/_layout/head.html
+++ b/_layout/head.html
@@ -38,6 +38,9 @@
   </style>
   {{end}}{{end}}
 
+  <!-- OGP Metadata -->
+  {{ifdef meta}}{{meta}}{{end}}
+
 </head>
 
 <body>

--- a/blog/2020/05/rr.md
+++ b/blog/2020/05/rr.md
@@ -4,7 +4,7 @@
 @def rss_pubdate = Date(2020, 5, 2)
 @def rss = """Julia 1.5 is gaining a cool new bug reporting capability, leveraging mozilla's rr project to automatically create fully-reproducible bug reports"""
 @def meta = ("property" => "og:video",
-             "content" => "http://example.com/bond/trailer.swf")
+             "content" => "https://julialang.org/assets/blog/2020-05-02-rr/preview.mp4")
 
 ~~~
   <link rel="stylesheet" type="text/css" href="/assets/blog/2020-05-02-rr/asciinema-player.css" />

--- a/blog/2020/05/rr.md
+++ b/blog/2020/05/rr.md
@@ -3,6 +3,8 @@
 @def title = "Coming in Julia 1.5: Time Traveling (Linux) Bug Reporting"
 @def rss_pubdate = Date(2020, 5, 2)
 @def rss = """Julia 1.5 is gaining a cool new bug reporting capability, leveraging mozilla's rr project to automatically create fully-reproducible bug reports"""
+@def meta = ("property" => "og:video",
+             "content" => "http://example.com/bond/trailer.swf")
 
 ~~~
   <link rel="stylesheet" type="text/css" href="/assets/blog/2020-05-02-rr/asciinema-player.css" />
@@ -197,7 +199,7 @@ If a bug report includes a link to an `rr` trace, in theory no further reproduct
 instructions are required. The `rr` trace is guaranteed to perfectly capture
 the environment the bug was reproduced in. Of course, if the bug is something non-obvious like
 unexpected behavior, some comments on what the expected behavior was may
-still be helpful. 
+still be helpful.
 Having perfect reproducability almost immediately knocks
 out all the common problems I started this post with. "Works for me" is no
 longer an available answer. If it's in the trace, it broke on somebody's machine

--- a/utils.jl
+++ b/utils.jl
@@ -1,0 +1,18 @@
+"""
+    {{meta}}
+
+Plug in specific meta information for a blog page. The `meta` local page
+variable should be given as a tuple of pairs like so:
+```
+@def meta = ("property"=>"og:video", "content"=>"http://example.com/")
+```
+"""
+function hfun_meta()
+    io = IOBuffer()
+    write(io, "<meta ")
+    for (k, v) in locvar(:meta)
+        write(io, "$k=\"$v\" ")
+    end
+    write(io, ">")
+    return String(take!(io))
+end

--- a/utils.jl
+++ b/utils.jl
@@ -6,13 +6,18 @@ variable should be given as a tuple of pairs like so:
 ```
 @def meta = ("property"=>"og:video", "content"=>"http://example.com/")
 ```
+Multiple meta tags can be specified that way too by just passing a list:
+```
+@def meta = [("property"=>"og:video", "content"=>"http://example.com/"),
+             ("propery"=>"og:title", "content"=>"The Rock")]
+```
 """
 function hfun_meta()
-    io = IOBuffer()
-    write(io, "<meta ")
-    for (k, v) in locvar(:meta)
-        write(io, "$k=\"$v\" ")
+    m = locvar(:meta)
+    if eltype(m) isa Pair
+        return _meta(m)
     end
-    write(io, ">")
-    return String(take!(io))
+    return prod(_meta.(m))
 end
+
+_meta(m) = "<meta " * prod("$k=\"$v\" " for (k, v) in m) * ">"


### PR DESCRIPTION
Blog pages which require specific additional information should now just add a `meta` page variable like so:

```
@def meta = ("property" => "og:video",
             "content" => "http://example.com/bond/trailer.swf")
```

where the first element of the pairs are valid meta attributes (property, content, name, ...). 
The above will lead to the inclusion  of

```html
<meta property="og:video" content="http://example.com/bond/trailer.swf" >
```

@Keno this is good to go apart from the `content` part in your blog post, if you just tell me what URL you want in there (or message), I'll fix it and merge. 