### PR TITLE
remove separator for current year

### DIFF
--- a/utils.jl
+++ b/utils.jl
@@ -30,10 +30,11 @@ end
 Plug in the list of blog posts contained in the `/blog/` folder.
 """
 function hfun_blogposts()
+    curyear = Dates.Year(Dates.today()).value
     io = IOBuffer()
-    for year in 2020:-1:2012
+    for year in curyear:-1:2012
         ys = "$year"
-        write(io, "\n**$year**\n")
+        year < curyear && write(io, "\n**$year**\n")
         for month in 12:-1:1
             ms = "0"^(1-div(month, 10)) * "$month"
             base = joinpath("blog", ys, ms)


### PR DESCRIPTION
As per comment on Slack.

### Before

![Screen Shot 2020-05-08 at 11 49 44](https://user-images.githubusercontent.com/10897531/81394329-137b8880-9122-11ea-9428-222b97e1e11f.png)

### After

![Screen Shot 2020-05-08 at 11 49 33](https://user-images.githubusercontent.com/10897531/81394340-18403c80-9122-11ea-8785-2d67c144c593.png)
