### PR TITLE
make font color of .main-heading black

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -440,7 +440,6 @@ img {
 }
 
 .page-heading .main-heading {
-  color: #fff;
   font-weight: 100;
 }
 .page-heading .secondary-heading {


### PR DESCRIPTION
white text on a light background makes the text unreadable. as the other text on the page has black font color on white background, making this also black increase consistency.