### PR TITLE
small fixes (edit button + empty cell separator on blog page)

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -626,15 +626,15 @@ table tr td {
     hyphens: auto;
 }
 
-@media only screen and (min-width: 800px){
+@media only screen and (min-width: 940px){
   .edit-float {
     background-image: url("../assets/infra/edit_icon.svg");
-    background-size: 30px 30px;
+    background-size: 25px 25px;
     background-repeat: no-repeat;
     background-position: center;
   	position:fixed;
-  	width:60px;
-  	height:60px;
+  	width:55px;
+  	height:55px;
   	bottom:40px;
   	right:30px;
   	background-color: #e6eeff;

--- a/utils.jl
+++ b/utils.jl
@@ -55,5 +55,11 @@ function hfun_blogposts()
             end
         end
     end
-    return Franklin.fd2html(String(take!(io)), internal=true)
+    # markdown conversion adds `<p>` beginning and end but
+    # we want to  avoid this to avoid an empty separator
+    r = Franklin.fd2html(String(take!(io)), internal=true)
+    startswith(r, "<p>")    && (r = chop(r, head=3))
+    endswith(r,   "</p>")   && (r = chop(r, tail=4))
+    endswith(r,   "</p>\n") && (r = chop(r, tail=5))
+    return r
 end


### PR DESCRIPTION
* makes edit button smaller + only appears on page width >= 940px
* small hack to avoid empty cell on the blog post page

These are small fixes, will  merge after checking the preview looks ok.