### PR TITLE
Move RSS-icon to the right

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -190,6 +190,11 @@
   font-family: "Roboto", sans-serif;
 }
 
+.rss-icon {
+  color: #e2802f;
+  float: right;
+}
+
 .blog {
   /* font-family: "Futura LT Medium"; */
   font-family: "Roboto", sans-serif;

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -53,7 +53,7 @@
 <div class="container blog-title">
   {{isdef title}}<h1>{{fill title}}
     <a type="application/rss+xml" href="https://julialang.org/feed.xml">
-      <i style="color:#e2802f" class="fa fa-rss-square"></i>
+      <i class="fa fa-rss-square rss-icon"></i>
     </a>
   </h1>{{end}}
   <h3>


### PR DESCRIPTION
Also adds a `.rss-icon` class since it's easier to keep track of styles that way.

Source: https://github.com/JuliaLang/www.julialang.org/issues/789#issuecomment-627848279