### PR TITLE
Use full width for blog posts on mobile

### DIFF
--- a/_layout/head.html
+++ b/_layout/head.html
@@ -25,14 +25,12 @@
     .main pre {
   	  margin-left: auto;
   	  margin-right: auto;
-  	  width: 90%;
     }
-    .main { width: 75%; font-size: 100%; }
+    .main { width: 100%; font-size: 100%; }
     .main code { font-size: 90%; }
     .main pre code { font-size: 90%; }
-    .container.blog-title { width: 75%; }
     @media (min-width: 940px) {
-      .main { width: 800px;}
+      .main { width: 800px; }
       .container.blog-title { width: 800px;}
     }
   </style>


### PR DESCRIPTION
Looks much better this way, especially on mobile devices. I'm wondering why such change was implemented in the first place.