### PR TITLE
Automatic recent posts on front page

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -634,16 +634,16 @@ table tr td {
 @media only screen and (min-width: 970px){
   .edit-float {
     background-image: url("../assets/infra/edit_icon.svg");
-    background-size: 25px 25px;
+    background-size: 18px 18px;
     background-repeat: no-repeat;
     background-position: center;
   	position:fixed;
-  	width:55px;
-  	height:55px;
+  	width:45px;
+  	height:45px;
   	bottom:40px;
   	right:30px;
   	background-color: #e6eeff;
-  	border-radius:50px;
+  	border-radius:40px;
   	text-align:center;
   	box-shadow: 2px 2px 3px #999;
 

--- a/blog/2020/02/gci-summary.md
+++ b/blog/2020/02/gci-summary.md
@@ -2,7 +2,7 @@
 @def published = "10 February 2020"
 @def title = "Google's Code-In Contest Wrap up"
 @def rss_pubdate = Date(2020, 2, 10)
-@def rss = """Over the last couple of months, 212 young people have completed over 690 tasks using Julia as part of the Google Code-In program. You may have seen PR’s to your projects or blog posts around the internet. With this being the first year that we’ve participated in the program,..."""
+@def rss = """Over the last couple of months, 212 young people have completed over 690 tasks using Julia as part of the Google Code-In program."""
 
 Over the last couple of months, 212 young people have completed over [690 tasks using Julia](https://codein.withgoogle.com/tasks/?sp-organization=6302639764013056) as part of the Google Code-In program. You may have seen PR’s to your projects or blog posts around the internet.
 With this being the first year that we’ve participated in the program, we were jumping into the void.  It turned out to be a lot of effort, and so we must thank our amazing set of mentors who stepped up to help and guide the students. It would not have been possible without their participation and a substantial commitment.

--- a/index.html
+++ b/index.html
@@ -441,23 +441,7 @@ end
     where the inserted element would be a generated file-->
 
     <div class="row">
-        <!-- Recent blog post 1 -->
-        <div class="col-lg-4 col-md-12 blog">
-          <h3><a href="/blog/2020/02/gci-summary/" class="title" data-proofer-ignore>Google&#39;s Code-In Contest Wrap up</a>
-          </h3><span class="article-date">10 February 2020</span> <p>Over the last couple of months, 212 young people have completed over 690 tasks using Julia as part … </p>
-        </div>
-        <!-- Recent blog post 2 -->
-        <div class="col-lg-4 col-md-12 blog">
-          <h3><a href="/blog/2019/12/yao-differentiable-quantum-programming/" class="title" data-proofer-ignore>Yao.jl - Differentiable Quantum Programming In Julia</a></h3>
-          <span class="article-date">28 December 2019</span>
-          <p>We introduce Yao (check our latest paper), an open-source Julia package for solving practical …</p>
-        </div>
-        <!-- Recent blog post 3 -->
-        <div class="col-lg-4 col-md-12 blog">
-          <h3><a href="/blog/2019/12/artifacts-zh_cn/" class="title" data-proofer-ignore>为 Julia 包设计的可靠、可复现的二进制工件系统</a></h3>
-          <span class="article-date">18 December 2019</span>
-          <p>在过去的几个月里，我们在持续迭代和完善一个 Julia 1.3+ 中 Pkg 的设计方案，它用来处理不是 Julia 包的二进制对象。这项工作当初的动机是改善用 BinaryBuilder.jl 构建 …</p>
-        </div>
+        {{recentblogposts}}
     </div>
 
     <br>

--- a/utils.jl
+++ b/utils.jl
@@ -63,3 +63,27 @@ function hfun_blogposts()
     endswith(r,   "</p>\n") && return chop(r, tail=5)
     return r
 end
+
+"""
+    {{recentblogposts}}
+
+Input the 3 latest blog posts.
+"""
+function hfun_recentblogposts()
+    # go in reverse order until 3 file paths are recovered
+    # for each file path
+    #   retrieve date
+    #   retrieve a blurb (could have a blog page var blurb to make it easier)
+    #   write div as below
+    io = IOBuffer()
+    for post in posts
+        write(io, """
+            <div class="col-lg-4 col-md-12 blog">
+              <h3><a href="$url" class="title">$title</a>
+              </h3><span class="article-date">$date</span>
+              $blurb
+            </div>
+            """)
+    end
+    return String(take!(io))
+end

--- a/utils.jl
+++ b/utils.jl
@@ -40,18 +40,25 @@ function hfun_blogposts()
             base = joinpath("blog", ys, ms)
             isdir(base) || continue
             posts = filter!(p -> endswith(p, ".md"), readdir(base))
-            for post in posts
+            days  = zeros(Int, length(posts))
+            lines = Vector{String}(undef, length(posts))
+            for (i, post) in enumerate(posts)
                 ps  = splitext(post)[1]
                 url = "/blog/$ys/$ms/$ps/"
                 surl = strip(url, '/')
                 title = pagevar(surl, :title)
                 pubdate = pagevar(surl, :published)
                 if isnothing(pubdate)
-                    date = "$ys-$ms-10"
+                    date    = "$ys-$ms-01"
+                    days[i] = 1
                 else
-                    date = Date(pubdate, dateformat"d U Y")
+                    date    = Date(pubdate, dateformat"d U Y")
+                    days[i] = day(date)
                 end
-                write(io, "\n[$title]($url) $date \n")
+                lines[i] = "\n[$title]($url) $date \n"
+            end
+            for line in lines[sortperm(days, rev=true)]
+                write(io, line)
             end
         end
     end
@@ -64,26 +71,34 @@ function hfun_blogposts()
     return r
 end
 
-"""
-    {{recentblogposts}}
-
-Input the 3 latest blog posts.
-"""
-function hfun_recentblogposts()
-    # go in reverse order until 3 file paths are recovered
-    # for each file path
-    #   retrieve date
-    #   retrieve a blurb (could have a blog page var blurb to make it easier)
-    #   write div as below
-    io = IOBuffer()
-    for post in posts
-        write(io, """
-            <div class="col-lg-4 col-md-12 blog">
-              <h3><a href="$url" class="title">$title</a>
-              </h3><span class="article-date">$date</span>
-              $blurb
-            </div>
-            """)
-    end
-    return String(take!(io))
-end
+# """
+#     {{recentblogposts}}
+#
+# Input the 3 latest blog posts.
+# """
+# function hfun_recentblogposts()e
+#     curyear = Dates.Year(Dates.today()).value
+#     nfound = 0
+#     for year in curyear:-1:2019
+#         for month in 12:-1:1
+#
+#         end
+#     end
+#
+#     # go in reverse order until 3 file paths are recovered
+#     # for each file path
+#     #   retrieve date
+#     #   retrieve a blurb (could have a blog page var blurb to make it easier)
+#     #   write div as below
+#     io = IOBuffer()
+#     for post in posts
+#         write(io, """
+#             <div class="col-lg-4 col-md-12 blog">
+#               <h3><a href="$url" class="title">$title</a>
+#               </h3><span class="article-date">$date</span>
+#               $blurb
+#             </div>
+#             """)
+#     end
+#     return String(take!(io))
+# end


### PR DESCRIPTION
This probably used to be there with Hugo then got lost in the migration to Franklin, now brought back: finds the 3 most recent blog posts and links to them on the front page.

I'll double check the preview & merge as it otherwise looks identical  to what was there before, only removes the need to  manually update that list.

Also fixes the ordering issue mentioned in #806

Also reduces the "edit this page" button to ~75% of its size (https://github.com/JuliaLang/www.julialang.org/pull/790#issuecomment-628075063)