### PR TITLE
Allow JuliaCon alert to be closed

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -512,6 +512,7 @@ blockquote p {
   padding-right: 0;
 }
 #top-alert .alert {
+  border-radius: 0;
   margin-bottom: 0.2rem;
 }
 #top-alert p {

--- a/index.html
+++ b/index.html
@@ -9,9 +9,13 @@
 
 <body>
   <div class="container-fluid" id="top-alert">
-    <div class="alert alert-dark mb-0" role="alert">
+    <div class="alert alert-dark alert-dismissible mb-0" role="alert">
       <p class="text-center">
         JuliaCon is online and free this year. <a href="https://juliacon.org/2020/tickets/">Register now</a> for JuliaCon 2020!
+			</p>
+			<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+				<span aria-hidden="true">&times;</span>
+			</button>
     </div>
   </div>
 
@@ -674,6 +678,15 @@ end
 <!-- FOOT -->
 
 {{insert foot_general.html}}
-
+<script>
+	$topAlert = $('#top-alert .alert');
+	const closed = JSON.parse(localStorage.getItem('closed'));
+	if (closed) {
+		$topAlert.alert('close');
+	}
+	$topAlert.on('close.bs.alert', function () {
+		localStorage.setItem('closed', true);
+	});
+</script>
 </body>
 </html>


### PR DESCRIPTION
Looks like this:

![Screenshot from 2020-05-14 16-24-38](https://user-images.githubusercontent.com/2725611/81946255-71670f00-95ff-11ea-8a00-8eede99fb32e.png)

Once closed, the preference is remembered in localStorage.