### PR TITLE
Redesign page heading

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -400,10 +400,12 @@ h4.card-title {
 .btn-primary {
   background-color: #4D64AE;
 }
-.btn-success,
-.btn-primary {
-  border: 1px solid rgba(0,0,0, 0.25);
+.page-heading .btn-success,
+.page-heading .btn-primary {
+  border-color: transparent;
+  box-shadow: 0px 0px 0px 3px #0a0a0a;
 }
+
 
 .link {
   color: #4D64AE;
@@ -438,7 +440,7 @@ img.ecosystem-image {
 .page-heading {
   color: #fff;
   padding: 3rem;
-  background-image: url('../assets/infra/splash-img.png');
+  background-image: url('https://raw.githubusercontent.com/cormullion/graphics/ed1bbef52ae2081a5a192f23d35a0cb9b38b8d30/svg-banners/backsplash-3.svg');
   background-repeat: repeat-x;
   background-size: auto 100%;
 }
@@ -453,6 +455,11 @@ img.ecosystem-image {
   margin-bottom: 2rem;
 }
 
+.page-heading .main-heading,
+.page-heading .secondary-heading {
+  text-shadow: 3px 3px #0a0a0a;
+}
+
 .page-heading p {
   margin-bottom: 0;
 }
@@ -460,6 +467,7 @@ img.ecosystem-image {
 .page-heading span.btn {
   padding-left: 0;
   padding-right: 0;
+  vertical-align: middle;
 }
 
 img {

--- a/_css/app.css
+++ b/_css/app.css
@@ -64,12 +64,6 @@
   margin-bottom: 50px;
 }
 
-.page-heading a {
-  /* font-family: "Futura LT Medium"; */
-  font-family: "Roboto", sans-serif;
-  font-weight: 400;
-}
-
 .extra-link {
   font-size: 12px;
   text-decoration: none !important;
@@ -292,10 +286,6 @@
   font-family: "Roboto", sans-serif;
 }
 
-.btn-success {
-	background-color: #008a00;
-}
-
 .btn-outline-primary {
 	color: #0072ee;
 }
@@ -404,10 +394,17 @@ h4.card-title {
   }
 }
 
+.btn-success {
+  background-color: #008a00;
+}
 .btn-primary {
   background-color: #4D64AE;
-  border-color: #4D64AE;
 }
+.btn-success,
+.btn-primary {
+  border: 1px solid rgba(0,0,0, 0.25);
+}
+
 .link {
   color: #4D64AE;
 }
@@ -438,26 +435,35 @@ img.ecosystem-image {
   margin-right: 20px;
 }
 
-.jumbotron {
+.page-heading {
+  color: #fff;
+  padding: 3rem;
   background-image: url('../assets/infra/splash-img.png');
   background-repeat: repeat-x;
   background-size: auto 100%;
 }
 
+.page-heading .main-heading {
+  font-weight: 100;
+  margin-bottom: 2rem;
+}
+
+.page-heading .secondary-heading {
+  font-size: 28px;
+  margin-bottom: 2rem;
+}
+
+.page-heading p {
+  margin-bottom: 0;
+}
+
+.page-heading span.btn {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 img {
   max-width: 100%;
-}
-
-.page-heading .main-heading {
-  color: #fff;
-  font-weight: 100;
-}
-.page-heading .secondary-heading {
-  color: #ccc;
-}
-
-.jumbotron a.link {
-  color: #ccc;
 }
 
 h1 {
@@ -526,10 +532,6 @@ blockquote p {
 }
 #top-alert p {
   margin-bottom: 0;
-}
-
-#main-jumbo {
-  padding: 3rem 2rem;
 }
 
 code, table.benchmarks tbody {

--- a/index.html
+++ b/index.html
@@ -25,30 +25,19 @@
        Splash 'THE JULIA PROGRAMMING LANGUAGE'
   -->
   <div class="container">
-    <div class="jumbotron" style="text-align: center;" id="main-jumbo">
-      <div class="container page-heading">
-        <h1 class="display-5 main-heading">
-          The Julia Programming Language
-        </h1>
-        <br>
-        <div class="row">
-          <div class="col"></div>
-          <div class="col-lg-auto col-md-auto col-sm-auto">
-            <a class="btn btn-success btn-lg btn-block" href="/downloads/" role="button">Download v{{stable_release_short}}</a>
-          <br>
-          </div>
-          <div class="col-lg-auto col-md-auto col-sm-auto docs">
-            <a class="btn btn-primary btn-lg btn-block" href="https://docs.julialang.org" role="button">Documentation</a>
-          <br>
-          </div>
-          <div class="col"></div>
-        </div>
-        <div class="row">
-          <div class="col"></div>
-          <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
-          <div class="col"></div>
-        </div>
-      </div>
+    <div class="jumbotron page-heading">
+      <h1 class="main-heading">
+        The Julia Language
+      </h1>
+      <h2 class="secondary-heading">
+        A fresh approach to technical computing.
+      </h2>
+
+      <a class="btn btn-success btn-lg" href="/downloads/" role="button">Download</a>
+      <a class="btn btn-primary btn-lg" href="https://docs.julialang.org" role="button">Documentation</a>
+      <span class="btn float-md-right">
+        <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
+      </span>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -30,14 +30,17 @@
         The Julia Language
       </h1>
       <h2 class="secondary-heading">
-        A fresh approach to technical computing.
+        A fresh approach to technical computing. 
       </h2>
 
+      <p>
       <a class="btn btn-success btn-lg" href="/downloads/" role="button">Download</a>
+      &nbsp;
       <a class="btn btn-primary btn-lg" href="https://docs.julialang.org" role="button">Documentation</a>
       <span class="btn float-md-right">
         <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
       </span>
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
There are some apparent problems with the front page's heading, the most visible thing on it. It gives the feel of some unmaintained, poorly-designed website. The problems are:

1. Lack of Julia's description
2. Poorly spaced buttons
3. Bad button styles (e.g. green button's border)

I recalled the phrase "We are greedy: we want more" and decided to redesign the page heading completely.

Before:
![Screenshot from 2020-05-14 18-43-40](https://user-images.githubusercontent.com/2725611/81961633-ea239680-9612-11ea-8bc8-f4eda02c3d3f.png)
After:
![Screenshot from 2020-05-14 19-03-59](https://user-images.githubusercontent.com/2725611/81963665-aed69700-9615-11ea-95e9-69348a11df11.png)

Some of @cormullion's SVG banners also style very nicely in this layout. Examples:
![Screenshot from 2020-05-14 19-16-14](https://user-images.githubusercontent.com/2725611/81964802-67e9a100-9617-11ea-9ead-b2f8492fa378.png)
![Screenshot from 2020-05-14 19-16-01](https://user-images.githubusercontent.com/2725611/81964807-691ace00-9617-11ea-915b-e856c843e6c3.png)
![Screenshot from 2020-05-14 19-15-39](https://user-images.githubusercontent.com/2725611/81964810-69b36480-9617-11ea-94ae-99eec8579be4.png)
