### PR TITLE
Prevent closing of the future top alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,11 @@
 <body>
   <div class="container-fluid" id="top-alert">
     <div class="alert alert-dark alert-dismissible mb-0" role="alert">
+      <!-- Only this <p> element should be changed in an alert -->
       <p class="text-center">
         JuliaCon is online and free this year. <a href="https://juliacon.org/2020/tickets/">Register now</a> for JuliaCon 2020!
 			</p>
+			<!-- Nothing more! -->
 			<button type="button" class="close" data-dismiss="alert" aria-label="Close">
 				<span aria-hidden="true">&times;</span>
 			</button>
@@ -30,7 +32,7 @@
         The Julia Language
       </h1>
       <h2 class="secondary-heading">
-        A fresh approach to technical computing. 
+        A fresh approach to technical computing.
       </h2>
 
       <p>
@@ -654,14 +656,15 @@ end
 
 {{insert foot_general.html}}
 <script>
-	$topAlert = $('#top-alert .alert');
-	const closed = JSON.parse(localStorage.getItem('closed'));
-	if (closed) {
-		$topAlert.alert('close');
-	}
-	$topAlert.on('close.bs.alert', function () {
-		localStorage.setItem('closed', true);
-	});
+  $topAlert = $('#top-alert .alert');
+  const alertText = $('#top-alert p').html().trim();
+  const alertClosed = JSON.parse(localStorage.getItem(alertText));
+  if (alertClosed) {
+    $topAlert.alert('close');
+  }
+  $topAlert.on('close.bs.alert', function () {
+    localStorage.setItem(alertText, true);
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
Source: https://github.com/JuliaLang/www.julialang.org/pull/809#issuecomment-629719225

In case `.alert`'s `p` element gets changed (after being trimmed), a the local storage key name gets changed too.

Example:
![Screenshot from 2020-05-17 12-30-27](https://user-images.githubusercontent.com/2725611/82142096-3b619f00-983a-11ea-9f1b-a3192eb66885.png)
I changed an exclamation mark to a period at the end of the sentence, and alert appeared again. Once I closed it, a new key appeared.