### PR TITLE
Remove ecosystems.html

### DIFF
--- a/ecosystems.html
+++ b/ecosystems.html
@@ -1,7 +1,0 @@
-<!-- REDIRECT -->
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/community/" />
-  </head>
-</html>


### PR DESCRIPTION
The webpage https://julialang.org/ecosystems/` is probably from the old website, but it isn't referenced in any other page (not even the sitemap). https://www.google.com/search?q=www.julialang.org%2Fecosystems also gives no results (except the www_old website, which is inaccessible). Currently it points to `community/`, but that doesn't make much sense, since the ecosystem is best described by the `Ecosystem` section in `index.html`.

If it doesn't generate any views (check in Google Analytics), then I suggest removing it.