### PR TITLE
Expand BioJulia description, and add link to BioJulia website

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -189,7 +189,7 @@ The following is a non-comprehensive list of Julia GitHub groups grouped by doma
 ### Scientific Domains
 
 @@tight-list
-* [BioJulia](https://github.com/BioJulia) – Biology ([Gitter](https://gitter.im/BioJulia/home))
+* [BioJulia](https://github.com/BioJulia) – Biology, bioinformatics, computational biology ([website](https://biojulia.net), [Gitter](https://gitter.im/BioJulia/home))
 * [EcoJulia](https://github.com/EcoJulia) – Ecology
 * [JuliaAstro](https://github.com/JuliaAstro) – [Astronomy](https://juliaastro.github.io/) ([Gitter](https://gitter.im/JuliaAstro/home))
 * [JuliaDSP](https://github.com/JuliaDSP) – Digital signal processing


### PR DESCRIPTION
This pull request makes the following changes:
1. Expands the description for the BioJulia organization
2. Adds a link to the BioJulia website

cc: @BenJWard @jakobnissen 