### PR TITLE
Restyle page-heading to use full width

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -446,6 +446,7 @@ img.ecosystem-image {
   background-image: url('../assets/infra/backsplash-min-0.5.svg');
   background-repeat: repeat-x;
   background-size: auto 100%;
+  border-radius: 0;
 }
 
 .page-heading .main-heading {

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
   <!--
        Splash 'THE JULIA PROGRAMMING LANGUAGE'
   -->
-  <div class="container">
     <div class="jumbotron page-heading">
+      <div class="container">
       <h1 class="main-heading">
         The Julia Language
       </h1>
@@ -44,7 +44,7 @@
       </span>
       </p>
     </div>
-  </div>
+    </div>
 
   <!--
        Containers: JULIA IN A NUTSHELL


### PR DESCRIPTION
I'm opening this just as a proposal which may be liked more than the current look. The current one feels more comfy, while the proposed one may catch more attention.

Before:
![Screenshot from 2020-05-29 01-18-05](https://user-images.githubusercontent.com/2725611/83203719-64dbce00-a14a-11ea-896c-8523f42b8eb0.png)
After:
![Screenshot from 2020-05-29 01-17-54](https://user-images.githubusercontent.com/2725611/83203723-66a59180-a14a-11ea-945b-c6b7356ba597.png)

