### PR TITLE
Reformat footer styles

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -302,37 +302,46 @@
 	color: #d91b35;
 }
 
-.footer-menu {
-  background-color: #394059;
-  color: #fff;
-  /* font-family: "Futura LT Medium"; */
-  font-family: "Roboto", sans-serif;
-}
-.footer-menu h6 {
-  /* font-family: "Futura LT Medium"; */
-  font-family: "Roboto", sans-serif;
-  font-weight: 500;
-  font-size: 14px;
-}
-.footer-menu ul.nav li a {
-  padding: 3px 0;
-  /* font-family: "Futura LT Medium"; */
-  font-family: "Roboto", sans-serif;
-  font-size: 13px;
-  color: #fff;
-}
-
 .footer-copy {
-  background-color: #2C2F3E;
+  background-color: #2c2f3e;
   color: #fff;
-  /* font-family: "Futura LT Medium"; */
-  font-family: "Roboto", sans-serif;
-  font-size: 16px;
-  padding: 10px 0;
+  padding-top: 2em;
+  margin-left: auto;
+  margin-right: auto;
 }
 .footer-copy p {
   padding: 0;
   margin: 0;
+}
+.footer-copy ul {
+  display: inline-block;
+  list-style: none;
+}
+.footer-copy ul a {
+  font-size: 95%;
+  color: #fff;
+}
+
+.footer-copy li:first-child a {
+  font-size: 110%;
+  font-weight: bold;
+  color: #7a95dd;
+}
+.footer-copy #footer-bottom {
+  font-size: 90%;
+}
+.footer-copy #footer-bottom a {
+  color: #7a95dd;
+}
+
+.footrow ul {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+@media (min-width: 800px) {
+  .footrow ul {
+    width: 20%;
+  }
 }
 
 h4.card-title {
@@ -412,10 +421,6 @@ h4.card-title {
 
 .link {
   color: #4D64AE;
-}
-
-.footer-menu-item {
-  margin-top: 30px;
 }
 
 #ecosystem-tab-content div.tab-pane {
@@ -504,10 +509,6 @@ h4 {
 
 a {
 	color: #005bc0;
-}
-
-.footer-heading{
-  color:#4D64AE;
 }
 
 

--- a/_layout/foot_general.html
+++ b/_layout/foot_general.html
@@ -1,80 +1,39 @@
-<style>
-  .footer-copy {
-    padding-top: 2em;
-    margin-left: auto;
-    margin-right: auto;}
-  .footer-copy ul#fmenu {
-      display:inline-block;
-  }
-  .footer-copy ul#fmenu li a {
-    font-size: 95%;
-    color: #fff;}
-  .footer-copy ul#fmenu li {
-    list-style: none;}
-  .footer-copy ul#fmenu a#fmhead {
-    font-size: 110%;
-    font-weight: bold;
-    color: #7a95dd;}
-  .footer-copy #footer-bottom {
-    font-size:90%;}
-  .footer-copy #footer-bottom a {
-    color: #7a95dd;}
-
-  .footrow {
-    padding-left: 15px;
-  }
-  .footrow ul {
-    padding-left: 0;
-    padding-right: 20px;
-  }
-  @media (min-width: 800px){
-    .footrow{
-      margin-left:auto;
-      margin-right:auto;
-      max-width: 1000px;
-    }
-    .footrow ul {
-      width:20%;
-    }
-  }
-</style>
-
 <footer class="container-fluid footer-copy">
   <div class="container">
     <div class="row footrow">
-      <ul id="fmenu">
-        <li><a id="fmhead" href="/project">About</a></li>
+      <ul>
+        <li><a href="/project">About</a></li>
         <li><a href="/about/help">Get Help</a></li>
         <li><a href="/community/#julia_github_groups">Domains</a></li>
         <li><a href="/blog/2019/02/julia-entities/">Governance</a></li>
         <li><a href="/research/#publications">Publications</a></li>
         <li><a href="/research/#sponsors">Sponsors</a></li>
       </ul>
-      <ul id="fmenu">
-        <li><a id="fmhead" href="/downloads/">Downloads</a></li>
+      <ul>
+        <li><a href="/downloads/">Downloads</a></li>
         <li><a href="/downloads/">All Releases</a></li>
         <li><a href="https://github.com/JuliaLang/julia">Source Code</a></li>
         <li><a href="/downloads/#current_stable_release">Current Stable Release</a></li>
         <li><a href="/downloads/#long_term_support_release">Longterm Support Release</a></li>
         <li><a href="/downloads/platform/#platform_specific_instructions_for_unofficial_binaries">Unofficial Binaries</a></li>
       </ul>
-      <ul id="fmenu">
-        <li><a id="fmhead" href="https://docs.julialang.org/en/v1/">Documentation</a></li>
+      <ul>
+        <li><a href="https://docs.julialang.org/en/v1/">Documentation</a></li>
         <li><a href="https://www.youtube.com/user/JuliaLanguage">Video Talks</a></li>
         <li><a href="/learning/getting-started/">Beginners Guide</a></li>
         <li><a href="https://docs.julialang.org/en/v1/manual/faq/">FAQ</a></li>
         <li><a href="/learning/#books">Julia Books</a></li>
       </ul>
-      <ul id="fmenu">
-        <li><a id="fmhead" href="/community/">Community</a></li>
+      <ul>
+        <li><a href="/community/">Community</a></li>
         <li><a href="/community/#2019_julia_user_and_developer_survey">User/Developer Survey</a></li>
         <li><a href="/diversity/">Diversity</a></li>
         <li><a href="/community/#official_channels">Official Channels</a></li>
         <li><a href="/community/standards/">Code of Conduct</a></li>
         <li><a href="/community/#events">Events</a></li>
       </ul>
-      <ul id="fmenu">
-        <li><a id="fmhead" href="https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md">Contributing</a></li>
+      <ul>
+        <li><a href="https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md">Contributing</a></li>
         <li><a href="https://github.com/JuliaLang/julia/issues">Issue Tracker</a></li>
         <li><a href="https://github.com/JuliaLang/julia/security/policy">Report a Security Issue</a></li>
         <li><a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+language%3AJulia+label%3A%22help+wanted%22">Help Wanted Issues</a></li>
@@ -88,7 +47,9 @@
         <p>©2020 JuliaLang.org <a href="https://github.com/JuliaLang/www.julialang.org/graphs/contributors">contributors</a>. The content on this website is made available under the <a href="https://github.com/JuliaLang/www.julialang.org/blob/master/LICENSE.md">MIT license</a>.
       </div>
       <div class="col-md-2 py-2">
-        <a class="github-button" href="https://github.com/sponsors/julialang" data-icon="octicon-heart" data-size="large" aria-label="Sponsor @julialang on GitHub">Sponsor</a>
+        <span class="float-sm-right">
+          <a class="github-button" href="https://github.com/sponsors/julialang" data-icon="octicon-heart" data-size="large" aria-label="Sponsor @julialang on GitHub">Sponsor</a>
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
A follow up to #845.

It cleans unused footer styles and avoids using the same IDs (`#fmenu` and `#fmhead`) for multiple elements. Also improves the centering:

![Screenshot from 2020-05-29 14-10-01](https://user-images.githubusercontent.com/2725611/83258238-35fb4180-a1b6-11ea-9d8b-998abeea496b.png)
->
![Screenshot from 2020-05-29 14-10-22](https://user-images.githubusercontent.com/2725611/83258235-3562ab00-a1b6-11ea-908b-33ec842a2111.png)
