### PR TITLE
Add the version number to download button on the frontpage.

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       </h2>
 
       <p>
-      <a class="btn btn-success btn-lg" href="/downloads/" role="button">Download</a>
+      <a class="btn btn-success btn-lg" href="/downloads/" role="button">Download v{{stable_release}}</a>
       &nbsp;
       <a class="btn btn-primary btn-lg" href="https://docs.julialang.org" role="button">Documentation</a>
       <span class="btn float-md-right">


### PR DESCRIPTION
Someone mentioned that the latest version of Julia was not displayed on the frontpage, and I think the download button is a nice way to display that:
![Screenshot from 2020-06-01 07-49-04](https://user-images.githubusercontent.com/11698744/83379779-a5eb1100-a3dc-11ea-8b56-26a0f0bc09c2.png)
