### PR TITLE
Add help text to help users decided between glibc and musl

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -82,7 +82,7 @@ It is strongly recommended that the official generic binaries from the downloads
 
 The generic Linux and FreeBSD binaries do not require any special installation steps, but you will need to ensure that your system can find the `julia` executable.
 
-First, download the `.tar.gz` file from the [downloads page](/downloads/). You need to extract this file to a suitable location. To extract the file, you can use the following command:
+First, download the `.tar.gz` file from the [downloads page](/downloads/). Most users would prefer the **glibc** version of the distirbution unless you know that your system uses **musl**. You need to extract this file to a suitable location. To extract the file, you can use the following command:
 
 ```
 tar -xvzf julia-x.y.z-linux-x86\_64.tar.gz

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -82,7 +82,7 @@ It is strongly recommended that the official generic binaries from the downloads
 
 The generic Linux and FreeBSD binaries do not require any special installation steps, but you will need to ensure that your system can find the `julia` executable.
 
-First, download the `.tar.gz` file from the [downloads page](/downloads/). Most users would prefer the `glibc` version of the distirbution unless you know that your system uses `musl` You need to extract this file to a suitable location. To extract the file, you can use the following command:
+First, download the `.tar.gz` file from the [downloads page](/downloads/). Most users would prefer the `glibc` version of the distribution unless you know that your system uses `musl`. You need to extract this file to a suitable location. To extract the file, you can use the following command:
 
 ```
 tar -xvzf julia-x.y.z-linux-x86\_64.tar.gz

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -82,7 +82,7 @@ It is strongly recommended that the official generic binaries from the downloads
 
 The generic Linux and FreeBSD binaries do not require any special installation steps, but you will need to ensure that your system can find the `julia` executable.
 
-First, download the `.tar.gz` file from the [downloads page](/downloads/). Most users would prefer the **glibc** version of the distirbution unless you know that your system uses **musl**. You need to extract this file to a suitable location. To extract the file, you can use the following command:
+First, download the `.tar.gz` file from the [downloads page](/downloads/). Most users would prefer the `glibc` version of the distirbution unless you know that your system uses `musl` You need to extract this file to a suitable location. To extract the file, you can use the following command:
 
 ```
 tar -xvzf julia-x.y.z-linux-x86\_64.tar.gz


### PR DESCRIPTION
I wanted to install the Linux distribution and it wasn't clear which version I should choose. Some Googling later, I think most people want the `glibc` version, which Mosè and Chris de Graaf on Slack confirmed was a better default choice.

Prior to 1.5 this didn't seem to be an issue as separate versions of the linux distribution is not shown.

An alternative might be to make the `glibc` version more prominent on the downloads page itself. 