### PR TITLE
Restyle hackathon codeblock

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,5 +1,5 @@
 # 404
 
- It appears that you have stumbled upon a page on the Julia website that does not yet exist. You may find it useful to start over at [https://www.julialang.org](https://www.julialang.org), or to navigate the Julia website using the links above.
+It appears that you have stumbled upon a page on the Julia website that does not yet exist. You may find it useful to start over at [https://www.julialang.org](https://www.julialang.org), or to navigate the Julia website using the links above.
 
 To improve this website, please [open an issue](https://github.com/julialang/www.julialang.org/issues) or [create a pull request](https://github.com/julialang/www.julialang.org/pulls).

--- a/_css/app.css
+++ b/_css/app.css
@@ -520,7 +520,6 @@ blockquote:before {
   vertical-align: -0.4em;
 }
 blockquote p {
-  display: inline;
   font-style: italic;
 }
 

--- a/hackathons.md
+++ b/hackathons.md
@@ -70,17 +70,19 @@ Password: 476732
 
 While not officially part of this Hackathon, there will be a talk titled: PackageCompiler and Static Compilation in Julia from 12pm – 1pm EDT on Friday. Details below: 
 
-```
-Register here https://form.jotform.me/200931129844454  for a free Webinar on "PackageCompiler and Static Compilation in Julia". 
+~~~<blockquote class="blockquote">~~~
 
- Know how one can use PackageCompiler.jl to cache the loading and compiled code of functions in packages, effectively removing the compilation overhead. 
+Register here [https://form.jotform.me/200931129844454](https://form.jotform.me/200931129844454) for a free Webinar on "PackageCompiler and Static Compilation in Julia".
+
+Know how one can use PackageCompiler.jl to cache the loading and compiled code of functions in packages, effectively removing the compilation overhead.
 
 You will also learn how to create apps - executable programs that can be run on other machines without requiring Julia installation and without having to provide the source code.
 
 The Webinar is led by Julia Computing's @KristofferC89, who is a long-time contributor to Julia, PackageCompiler.jl, the Julia package manager and debugger.
 
- #julialang
-```
+#julialang
+
+~~~</blockquote>~~~
 
 # Questions
 


### PR DESCRIPTION
It was an unreadable codeblock, now it looks like this:

![Screenshot from 2020-06-15 01-30-05](https://user-images.githubusercontent.com/2725611/84606632-f87e0000-aea7-11ea-8ebf-f282f0065bb6.png)

Blockquote style change in `app.css` is harmless, since no file uses `blockquote` (check `grep -R blockquote`). Without it, there are no line breaks inside blockquote.