### PR TITLE
Use meta tags consistently

### DIFF
--- a/_layout/head_scripts.html
+++ b/_layout/head_scripts.html
@@ -1,8 +1,8 @@
 <!-- NOTE: specific stylesheets, off for now -->
-<link rel="stylesheet" href="/libs/bootstrap/bootstrap.min.css" />
-<link rel="stylesheet" href="/css/app.css" />
-<link rel="stylesheet" href="/css/franklin.css" />
-<link rel="stylesheet" href="/css/fonts.css" />
+<link rel="stylesheet" href="/libs/bootstrap/bootstrap.min.css">
+<link rel="stylesheet" href="/css/app.css">
+<link rel="stylesheet" href="/css/franklin.css">
+<link rel="stylesheet" href="/css/fonts.css">
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,500,500i,700,700i" rel="stylesheet">
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 <script async defer src="/libs/buttons.js"></script>

--- a/_layout/meta.html
+++ b/_layout/meta.html
@@ -1,9 +1,8 @@
-<meta charset="UTF-8">
+<meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<meta name="author" content="Jeff Bezanson, Stefan Karpinski, Viral Shah, Alan Edelman, et al." />
-<meta name="description" content="The official website for the Julia Language. Julia is a language that is fast, dynamic, easy to use, and open source. Click here to learn more."/>
-<meta property="og:title" content="The Julia Language"/>
-<meta property="og:image" content="/assets/images/julia-open-graph.png"/>
-<meta property="og:description" content="Official website for the Julia programming language"/>
+<meta name="author" content="Jeff Bezanson, Stefan Karpinski, Viral Shah, Alan Edelman, et al.">
+<meta name="description" content="The official website for the Julia Language. Julia is a language that is fast, dynamic, easy to use, and open source. Click here to learn more.">
+<meta property="og:title" content="The Julia Language">
+<meta property="og:image" content="/assets/images/julia-open-graph.png">
+<meta property="og:description" content="Official website for the Julia programming language">

--- a/download.html
+++ b/download.html
@@ -1,7 +1,7 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/downloads/" />
+    <meta http-equiv="refresh" content="0; url=/downloads/">
   </head>
 </html>

--- a/ecosystems.html
+++ b/ecosystems.html
@@ -1,5 +1,5 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta http-equiv="refresh" content="0; url=/community/" />

--- a/license.html
+++ b/license.html
@@ -1,7 +1,7 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=https://github.com/JuliaLang/julia/blob/master/LICENSE.md" />
+    <meta http-equiv="refresh" content="0; url=https://github.com/JuliaLang/julia/blob/master/LICENSE.md">
   </head>
 </html>

--- a/manual.html
+++ b/manual.html
@@ -1,7 +1,7 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=https://docs.julialang.org/en/v1/" />
+    <meta http-equiv="refresh" content="0; url=https://docs.julialang.org/en/v1/">
   </head>
 </html>

--- a/soc/ideas-page.html
+++ b/soc/ideas-page.html
@@ -1,7 +1,7 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/jsoc/" />
+    <meta http-equiv="refresh" content="0; url=/jsoc/">
   </head>
 </html>

--- a/soc/index.html
+++ b/soc/index.html
@@ -1,7 +1,7 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/jsoc/" />
+    <meta http-equiv="refresh" content="0; url=/jsoc/">
   </head>
 </html>

--- a/teaching.html
+++ b/teaching.html
@@ -1,7 +1,7 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/learning/" />
+    <meta http-equiv="refresh" content="0; url=/learning/">
   </head>
 </html>

--- a/utf8proc.html
+++ b/utf8proc.html
@@ -1,7 +1,7 @@
 <!-- REDIRECT -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=https://juliastrings.github.io/utf8proc/" />
+    <meta http-equiv="refresh" content="0; url=https://juliastrings.github.io/utf8proc/">
   </head>
 </html>


### PR DESCRIPTION
1) `<meta http-equiv="content-type" content="text/html; charset=utf-8" />` is equivalent to <meta charset="utf-8">
https://stackoverflow.com/questions/51006665/what-is-meta-http-equiv-content-type-content-text-html-charset-utf-8/51006700#:~:text=is%20the,charset%20of%20your%20html%20document.&text=is%20the,to%20do%20the%20same%20thing.

2) Generally `<meta>` and `<link>` are preferred over `<meta />` and `<link />`. It's also less bytes to serve. In this site both are used, so I made it consistent.

3) same for doctype, just for the sake of consistency