### PR TITLE
Over 3500 packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@ end
 
       <br>
 
-      <p>Julia has been downloaded over 13 million times and the Julia community has registered <a href="https://juliahub.com">over 3,000 Julia packages</a> for community use.
+      <p>Julia has been downloaded over 13 million times and the Julia community has registered <a href="https://juliahub.com">over 3,500 Julia packages</a> for community use.
       These include various mathematical libraries, data manipulation tools, and packages for general purpose computing. In addition to these, you can easily use libraries from <a href="https://github.com/JuliaPy/PyCall.jl">Python</a>, <a href="https://github.com/JuliaInterop/RCall.jl">R</a>, <a href="https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#Calling-C-and-Fortran-Code-1">C/Fortran</a>, <a href="https://github.com/Keno/Cxx.jl">C++</a>, and <a href="https://github.com/JuliaInterop/JavaCall.jl">Java</a>.
       If you do not find what you are looking for, ask on <a href="https://discourse.julialang.org">Discourse</a>, or even better, <a href="https://julialang.github.io/Pkg.jl/v1/">contribute one</a>!</p>
 


### PR DESCRIPTION
I saw over 3500 stated at Juliacomputing.com so I guess ok here. Before they didn't want to include with JLL packages, and without there are 3440, and with 3883 including the 16 waiting in the pipeline to be registered.

I find it likely "Julia has been downloaded over 13 million times" to be outdated. No July newsletter yet, this was in older.