### PR TITLE
Add portable builds for Windows

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -154,9 +154,14 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
 <table class="downloads table table-hover  table-bordered">
   <tbody>
     <tr>
-      <th> Windows Self-Extracting Archive (.exe) <a href="/downloads/platform/#windows">[help]</a></th>
+      <th> Windows (Installer) (.exe) <a href="/downloads/platform/#windows">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-win64.exe">64-bit</a> </td>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-win32.exe">32-bit</a> </td>
+    </tr>
+    <tr>
+      <th> Windows (Portable) (.tar.gz) <a href="/downloads/platform/#windows">[help]</a></th>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-win64.tar.gz">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-win32.tar.gz">32-bit</a> </td>
     </tr>
     <tr>
       <th> macOS 10.8+ Package (.dmg) <a href="/downloads/platform/#macos">[help]</a></th>


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/32158
Note only applies to newer builds since it depends on https://github.com/JuliaLang/julia/pull/35098

I'm not sure how much it matters but these are tarballs, which on newer Windows versions `tar` is shipped and is in the system path. 

Perhaps longer term we can instead offer zip builds?

 