### PR TITLE
"Essential Tools" section: Link to `juliagpu.org` instead of `github.com/JuliaGPU`

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,10 +642,10 @@ end
         </div>
         <div class="col-lg-3 col-md-6 ide ide-feature">
           <h3>GPUs</h3>
-		  	<a href="https://github.com/JuliaGPU" target="_blank">
+		  	<a href="https://juliagpu.org/" target="_blank">
             <img src="/assets/infra/gpu.png" height="85" width="85" alt="Julia GPU Logo" /></a>
           <h4 class="outer-link">
-            <a class="link extra-link" href="https://github.com/JuliaGPU" target="_blank">JuliaGPU</a>
+            <a class="link extra-link" href="https://juliagpu.org/" target="_blank">JuliaGPU</a>
           </h4>
         </div>
       </div>


### PR DESCRIPTION
Currently, in the "Essential Tools" section, the "GPUs" square links to `https://github.com/JuliaGPU`.

Perhaps, it would make more sense for the "GPUs" square to link to `https://juliagpu.org` instead? It's a nicer landing page and introduction to the Julia GPU ecosystem.