### PR TITLE
A better way of handling fork PRs vs non-fork PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install SSH Client
-        continue-on-error: true
+        if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name # if this build is NOT a PR build, OR if this build is a PR build and the PR is NOT from a fork
         uses: webfactory/ssh-agent@v0.2.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
@@ -45,8 +45,7 @@ jobs:
               using Franklin; optimize();
               cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"))'
       - name: Deploy (preview)
-        continue-on-error: true
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name # if this build is a PR build and the PR is NOT from a fork
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           SSH: true


### PR DESCRIPTION
Currently, we just use `continue-on-error: true` statements to prevent the build for erroring on PRs made from forks.

This is a rather rough approach. We can be more precise.

The best way to do this is to explicitly check whether or not the PR is made from a fork. We use this conditional:
```
github.repository == github.event.pull_request.head.repo.full_name
```

If the PR is made from a fork, then this conditional evaluates to `false`. If the PR is NOT made from a fork, then this conditional evaluates to `true`.

Therefore, we only push PR previews if the PR is not made from the fork.

Everything else is the same for both fork and non-fork PRs.