### PR TITLE
Fix in markdown syntax for 1.0 blogposts (en/es)

### DIFF
--- a/blog/2018/08/one-point-zero-es.md
+++ b/blog/2018/08/one-point-zero-es.md
@@ -5,7 +5,7 @@
 @def authors = "the Julia developers"  
 
 ~~~
-Translations:  <a href="/blog/2018/08/one-point-zero-zh_cn">Simplified Chinese</a>, <a href="/blog/2018/08/one-point-zero-zh_tw">Traditional Chinese</a>, <a href="/blog/2018/08/one-point-zero-es">Spanish</a>
+Translations:  <a href="/blog/2018/08/one-point-zero-zh_cn/">Simplified Chinese</a>, <a href="/blog/2018/08/one-point-zero-zh_tw/">Traditional Chinese</a>, <a href="/blog/2018/08/one-point-zero-es/">Spanish</a>
 ~~~
 
 La anticipada liberación de la versión 1.0 de [Julia](https://julialang.org) es la culminación de casi una década de trabajo de construir un lenguaje para programadores ambiciosos. JuliaCon2018 celebró la ocasión con un evento donde la comunidad oficialmente [lanzó conjuntamente la versión
@@ -26,107 +26,42 @@ Una comunidad vibrante y fructífera ha crecido alrededor de este lenguaje, con 
 todo el mundo iterativamente refinando y reformulado Julia para cumplir su meta. Más de 700
 personas han contribuido a Julia en sí y aún más gente han hecho miles de asombrosos paquetes de código abierto. En resumen, hemos construido un lenguaje que es:
 
-* **Rápido**: Julia fue diseñado desde el principio para tener alto rendimiento. Los programas de Julia
-  se compilan a código nativo eficiente para muchas plataformas por medio de LLVM.
+* **Rápido**: Julia fue diseñado desde el principio para tener alto rendimiento. Los programas de Julia se compilan a código nativo eficiente para muchas plataformas por medio de LLVM.
 * **General**: Usa despacho múltiple como paradigma, facilitando expresar muchos patrones de
-  la programación orientada a objetos ó programación funcional. La biblioteca estándar provee
-  I/O asíncrono, control de procesos, logging, perfiles, un administrador de paquetes y más.
-* **Técnico**: Sobresale en cómputo numérico con una sintaxis excelente para las matemáticas,
-  amplio soporte para muchos tipos de datos, y pararelismo incluido por default. Su despacho múltiple
-  es un embone natural para definir tipos de datos numéricos y de arreglos.
-* **Opcionalmente tipado**: Julia tiene un lenguaje rico para describir tipos de datos, y la declaración
-  de tipos puede ser usada para clarificar y solidificar programas.
-* **Componible**: Los paquetes de Julia se pueden simultáneamente sin dificultad. Matrices de cantidades
-  unitarias, ó datos de columnas tabuladas de divisas y colores -- todo funciona -- y a buena velocidad.
+la programación orientada a objetos ó programación funcional. La biblioteca estándar provee
+I/O asíncrono, control de procesos, logging, perfiles, un administrador de paquetes y más.
+* **Técnico**: Sobresale en cómputo numérico con una sintaxis excelente para las matemáticas, amplio soporte para muchos tipos de datos, y pararelismo incluido por default. Su despacho múltiple es un embone natural para definir tipos de datos numéricos y de arreglos.
+* **Opcionalmente tipado**: Julia tiene un lenguaje rico para describir tipos de datos, y la declaración de tipos puede ser usada para clarificar y solidificar programas.
+* **Componible**: Los paquetes de Julia se pueden simultáneamente sin dificultad. Matrices de cantidades unitarias, ó datos de columnas tabuladas de divisas y colores -- todo funciona -- y a buena velocidad.
 
-Prueba Julia bajando la [versión 1.0 ahora](https://julialang.org/downloads/). Si estás actualizando
-código de Julia 0.6 o versiones anteriores, te recomendamos que primero uses la versión 0.7 como transición. Una vez
-que tu código esté libre de advertencias (*warnings*), puedes cambiarlo a 1.0 sin ninguna pérdida de funcionalidad. Los paquetes registrados
-están aprovechando esta etapa de transición y liberando sus actualizaciones compatibles con 1.0.
+Prueba Julia bajando la [versión 1.0 ahora](https://julialang.org/downloads/). Si estás actualizando código de Julia 0.6 o versiones anteriores, te recomendamos que primero uses la versión 0.7 como transición.
+Una vez que tu código esté libre de advertencias (*warnings*), puedes cambiarlo a 1.0 sin ninguna pérdida de funcionalidad. Los paquetes registrados están aprovechando esta etapa de transición y liberando sus actualizaciones compatibles con 1.0.
 
-La ventaja más importante de Julia 1.0 es, por supuesto, es un compromiso de estabilidad de API:
-El código que escribes para Julia 1.0 seguirá funcionando en 1.1, 1.2, etc. El lenguaje está "completo".
-Los desarrolladores principales y la comunidad pueden enfocarse en la paquetería, herramientas, y nuevas
-funcionalidades construidas sobre una base sólida.
+La ventaja más importante de Julia 1.0 es, por supuesto, es un compromiso de estabilidad de API: El código que escribes para Julia 1.0 seguirá funcionando en 1.1, 1.2, etc. El lenguaje está "completo".
+Los desarrolladores principales y la comunidad pueden enfocarse en la paquetería, herramientas, y nuevas funcionalidades construidas sobre una base sólida.
 
 Sin embargo, Julia 1.0 no es solamente sobre estabilidad, también introduce nuevas y poderosas innovaciones del lenguaje.
 Algunas de estas novedades desde la versión 0.6 incluyen:
 
-* Un nuevo e incluido [administrador de paquetes](https://docs.julialang.org/en/latest/stdlib/Pkg/)
-  trae enormes mejoras de rendimiento y facilita más que nunca la instalación de paquetes y sus
-  dependencias. También soporta ambientes particulares para cada proyecto y registros de estado exactos para
-  una aplicación para poderla compartir con los demás - y tu futuro yo. Finalmente, el rediseño también introduce
-  soporte integrado para paquetes privados y repositorios. Tú puedes instalar y administrar paqueterías
-  privadas con las mismas herramientas que el ecosistema de paquetería abierta. La [presentación de
-  JuliaCon](https://www.youtube.com/watch?v=GBi__3nF-rM) resume el nuevo diseño y capacidades.
-
-* Julia tiene una nueva [representación canónica para valores faltantes](/blog/2018/06/missing).
-  Poder representar y trabajar con datos faltantes es fundamental para estadísticas y ciencias de datos. En estilo Juliano,
-  la nueva solución es general, componible y rápida. Cualquier colección general puede eficientemente
-  soportar valores faltantes simplemente al permitir que elementos incluyan el valor predefinido `missing`.
-  El rendimiento de dadas colecciones "tipadas como uniones" hubieran sido demasiado lento en versiones anteriores
-  de Julia, pero mejoras en el compilador permiten ahora que en Julia sea comparable a la velocidad de valores faltantes
-  en C ó C++ en otros sistemas, mientras que sigue siendo mucho más general y flexible.
-
-* El tipo `String` ahora puede contener datos arbitrarios. Tu programa no fallará después de horas ó días porque
-  un solo byte de Unicode era inválido. Todos los datos de cadenas de caracteres son preservados mientras que se indica cuáles caracteres
-  son válidos o inválidos, permitiendo que sus aplicaciones sean conveniente y seguramente usadas en datos reales con todas sus
-  inevitables complicaciones.
-
-* "Broadcasting" ya es una ventaja clave con sintaxis conveniente -- y ahora es más poderosa que nunca. En
-  Julia 1.0 es fácil [extender broadcasting a tipos del usuario](/blog/2018/05/extensible-broadcast-fusion) e implementarlo
-  en cálculos optimizados para GPUs y hardware vectorizado, pavimentando el camino para aún más mejoras en el futuro.
-
-* Las tuplas con nombre son rasgo nuevo que permite representar y accesar datos por nombre y de manera eficiente. Puedes, por ejemplo,
-  representar una hilera de datos como `row =
+* Un nuevo e incluido [administrador de paquetes](https://docs.julialang.org/en/latest/stdlib/Pkg/) trae enormes mejoras de rendimiento y facilita más que nunca la instalación de paquetes y sus dependencias. También soporta ambientes particulares para cada proyecto y registros de estado exactos para una aplicación para poderla compartir con los demás - y tu futuro yo. Finalmente, el rediseño también introduce  soporte integrado para paquetes privados y repositorios. Tú puedes instalar y administrar paqueterías  privadas con las mismas herramientas que el ecosistema de paquetería abierta. La [presentación de JuliaCon](https://www.youtube.com/watch?v=GBi__3nF-rM) resume el nuevo diseño y capacidades.
+* Julia tiene una nueva [representación canónica para valores faltantes](/blog/2018/06/missing). Poder representar y trabajar con datos faltantes es fundamental para estadísticas y ciencias de datos. En estilo Juliano,  la nueva solución es general, componible y rápida. Cualquier colección general puede eficientemente  soportar valores faltantes simplemente al permitir que elementos incluyan el valor predefinido `missing`. El rendimiento de dadas colecciones "tipadas como uniones" hubieran sido demasiado lento en versiones anteriores  de Julia, pero mejoras en el compilador permiten ahora que en Julia sea comparable a la velocidad de valores faltantes en C ó C++ en otros sistemas, mientras que sigue siendo mucho más general y flexible.
+* El tipo `String` ahora puede contener datos arbitrarios. Tu programa no fallará después de horas ó días porque  un solo byte de Unicode era inválido. Todos los datos de cadenas de caracteres son preservados mientras que se indica cuáles caracteres son válidos o inválidos, permitiendo que sus aplicaciones sean conveniente y seguramente usadas en datos reales con todas sus  inevitables complicaciones.
+* "Broadcasting" ya es una ventaja clave con sintaxis conveniente -- y ahora es más poderosa que nunca. En Julia 1.0 es fácil [extender broadcasting a tipos del usuario](/blog/2018/05/extensible-broadcast-fusion) e implementarlo  en cálculos optimizados para GPUs y hardware vectorizado, pavimentando el camino para aún más mejoras en el futuro.
+* Las tuplas con nombre son rasgo nuevo que permite representar y accesar datos por nombre y de manera eficiente. Puedes, por ejemplo,  representar una hilera de datos como `row =
   (name="Julia", version=v"1.0.0", releases=8)` y accesar su columna `version` como
   `row.version` con la misma velocidad que el inconveniente `row[2]`.
-
-* El operador punto ahora puede ser sobrecargado, permitiendo así que tipos usen la sintaxis `obj.propiedad` para
-  comportamientos que no sea accesar o fijar campos de structs. Esto es especialmente útil para facilitar
-  la interoperabilidad con lenguajes basados en clases como Python y Java. Esto también permite sobrecargar la
-  sintaxis para obtener una columna de datos y que empate con la de tuplas nombradas: puedes escribir
-  `tabla.versión` para accesar la columna `versión` de una tabla ó `row.versión` accesa el campo
-  `versión` de una sola hilera.
-
-* El optimizador de Julia se ha vuelto mucho más listo en demasiadas maneras como para aquí enlistarlas, pero
-  algunas de ellas vale la pena mencionar. El optimizador ahora nos permite propagar constantes a través de llamadas
-  a funciones, permitiendo mucha mejor eliminación de código muerto y evaluación estática que antes. El compilador
-  ahora también es mucho mejor evitando alocaciones de *wrappers* efímeros alrededor de objetos longevos, permitiendo
-  a los programadores a usar abstracciones de alto nivel sin costo de rendimiento.
-
-* Los constructores de tipos paramétricos ahora se llaman con la misma sintaxis con la que se declaran. Esto
-  elimina una barrera rebuscada pero confusa de sintaxis.
-
-* El protocolo de iteración ha sido completamente rediseñado para facilitar implementar muchos tipos de
-  iterables. En vez de —`start`, `next`, `done`—uno ahora define métodos de uno y dos argumentos para la función
-  `iterate`. Esto frecuentemente permite que la iteración se defina con un sólo método y un valor por default para
-  el estado inicial. Aunado a lo anterior, es posible implementar iteradores que solo saben si han terminado
-  una vez que han intentado y fallado en producir un valor -- justo el tipo de iteradores que son ubicuos en I/O,
-  producidores/consumidores, etc. Julia puede expresar estos iteradores directa y correctamente.
-
-* Las reglas de alcance han sido simplificadas. Las construcciones que introducen alcances locales ahora lo hacen
-  de manera consistente, sin importar los enlaces globales para nombre preexistentes o no. Esto elimina la distinción de
-  alcances "duros/suaves" que previamente existía y significa que Julia siempre puede determinar estáticamente si variables son
-  locales o globales.
-
-* El lenguaje en sí es significativamente más esbelto, con muchos componentes siendo escindidos a paquetes en la
-  "biblioteca estándar" que es liberada con Julia pero que no es parte del lenguaje "base". Si los necesitas, solo
-  necesitas importar (sin instalar) pero no estarás coaccionada a hacerlo. En el futuro, esto permitirá que las bibliotecas
-  estándar sean versionadas y actualizadas independientemente de Julia, permitiendo que evolucionen y se mejoren más rápido.
-
-* Hemos revisado extensamente todas las APIs de Julia para mejorar la consistencia y usabilidad. Muchos nombres
-  tradicionales rebuscados y patrones ineficientes han sido renombrados o refactorizados para empatar elegantemente con las capacidades de Julia.
-  Esto ha promovido cambios para trabajar con colecciones de manera más consistente y coherente, y asegurar que el orden de los argumentos
-  sea un estándar consistente a lo largo del lenguaje, y para incorporar los (ahora más rápidos) argumentos "keyword" en las APIs
-  apropiadas.
-
+* El operador punto ahora puede ser sobrecargado, permitiendo así que tipos usen la sintaxis `obj.propiedad` para  comportamientos que no sea accesar o fijar campos de structs. Esto es especialmente útil para facilitar  la interoperabilidad con lenguajes basados en clases como Python y Java. Esto también permite sobrecargar la  sintaxis para obtener una columna de datos y que empate con la de tuplas nombradas: puedes escribir  `tabla.versión` para accesar la columna `versión` de una tabla ó `row.versión` accesa el campo  `versión` de una sola hilera.
+* El optimizador de Julia se ha vuelto mucho más listo en demasiadas maneras como para aquí enlistarlas, pero  algunas de ellas vale la pena mencionar. El optimizador ahora nos permite propagar constantes a través de llamadas  a funciones, permitiendo mucha mejor eliminación de código muerto y evaluación estática que antes. El compilador  ahora también es mucho mejor evitando alocaciones de *wrappers* efímeros alrededor de objetos longevos, permitiendo a los programadores a usar abstracciones de alto nivel sin costo de rendimiento.
+* Los constructores de tipos paramétricos ahora se llaman con la misma sintaxis con la que se declaran. Esto  elimina una barrera rebuscada pero confusa de sintaxis.
+* El protocolo de iteración ha sido completamente rediseñado para facilitar implementar muchos tipos de iterables. En vez de —`start`, `next`, `done`—uno ahora define métodos de uno y dos argumentos para la función `iterate`. Esto frecuentemente permite que la iteración se defina con un sólo método y un valor por default para el estado inicial. Aunado a lo anterior, es posible implementar iteradores que solo saben si han terminado  una vez que han intentado y fallado en producir un valor -- justo el tipo de iteradores que son ubicuos en I/O, producidores/consumidores, etc. Julia puede expresar estos iteradores directa y correctamente.
+* Las reglas de alcance han sido simplificadas. Las construcciones que introducen alcances locales ahora lo hacen de manera consistente, sin importar los enlaces globales para nombre preexistentes o no. Esto elimina la distinción de alcances "duros/suaves" que previamente existía y significa que Julia siempre puede determinar estáticamente si variables son locales o globales.
+* El lenguaje en sí es significativamente más esbelto, con muchos componentes siendo escindidos a paquetes en la "biblioteca estándar" que es liberada con Julia pero que no es parte del lenguaje "base". Si los necesitas, solo necesitas importar (sin instalar) pero no estarás coaccionada a hacerlo. En el futuro, esto permitirá que las bibliotecas estándar sean versionadas y actualizadas independientemente de Julia, permitiendo que evolucionen y se mejoren más rápido.
+* Hemos revisado extensamente todas las APIs de Julia para mejorar la consistencia y usabilidad. Muchos nombres tradicionales rebuscados y patrones ineficientes han sido renombrados o refactorizados para empatar elegantemente con las capacidades de Julia. Esto ha promovido cambios para trabajar con colecciones de manera más consistente y coherente, y asegurar que el orden de los argumentos sea un estándar consistente a lo largo del lenguaje, y para incorporar los (ahora más rápidos) argumentos "keyword" en las APIs apropiadas.
 * Un gran número de paquetería externa ha sido específicamente construida alrededor de las ventajas de Julia 1.0, tales como:
-    * El ecosistema de procesamiento y manipulación de manejo de datos fue reorganizado alrededor de los valores faltantes.
+  * El ecosistema de procesamiento y manipulación de manejo de datos fue reorganizado alrededor de los valores faltantes.
+  * [Cassette.jl](https://github.com/jrevels/Cassette.jl) provee un poderoso mecanismo para inyectar pases de transformación de código al compilador de Julia, permitiendo análisis post-hoc y extensión de código existente. Además de la instrumentación para programadores como un debugger y un profiler, esto también puede implementar diferenciación automática para tareas de *machine learning*.
+  * Se ha incrementado enormemente el soporte para arquitecturas heterogéneas y se ha desacoplado aún más del funcionamiento interno del compilador. Los Intel KNLs funcionan en Julia. Los GPUs de Nvidia son programados usando [CUDANative.jl](https://github.com/JuliaGPU/CUDAnative.jl) y un port para los TPUs de Google está siendo desarrollado.
 
-    * [Cassette.jl](https://github.com/jrevels/Cassette.jl) provee un poderoso mecanismo para inyectar pases de transformación de código al compilador de Julia, permitiendo análisis post-hoc y extensión de código existente. Además de la instrumentación para programadores como un debugger y un profiler, esto también puede implementar diferenciación automática para tareas de *machine learning*.
-
-    * Se ha incrementado enormemente el soporte para arquitecturas heterogéneas y se ha desacoplado aún más del funcionamiento interno del compilador. Los Intel KNLs funcionan en Julia. Los GPUs de Nvidia son programados usando [CUDANative.jl](https://github.com/JuliaGPU/CUDAnative.jl) y un port para los TPUs de Google está siendo desarrollado.
 
 Éstas son solo algunas de las mejoras. Para una lista completa de los cambios, lee el archivo [0.7 NEWS](https://docs.julialang.org/en/release-0.7/NEWS/). En el post
 original [“Why We Created Julia” blog post](/blog/2012/02/why-we-created-julia) en 2012, escribimos

--- a/blog/2018/08/one-point-zero.md
+++ b/blog/2018/08/one-point-zero.md
@@ -1,10 +1,11 @@
-@def rss_pubdate = Date(2018, 8, 8)
-@def rss = """ Announcing the release of Julia 1.0 | The much anticipated 1.0 release of Julia (https://julialang.org) is the culmination of... """
-@def published = "8 August 2018"
 @def title = "Announcing the release of Julia 1.0"
 @def authors = "Julia developers"
+@def rss_pubdate = Date(2018, 8, 8)
+@def rss = "Announcing the release of Julia 1.0. The much anticipated 1.0 release of Julia is the culmination of..."
+@def published = "8 August 2018"
 
-~~~Translations:  <a href="/blog/2018/08/one-point-zero-zh_cn">Simplified Chinese</a>, <a href="/blog/2018/08/one-point-zero-zh_tw">Traditional Chinese</a>, <a href="https://julialang.org/blog/2018/08/one-point-zero-es">Spanish</a>
+~~~
+Translations: <a href="/blog/2018/08/one-point-zero-zh_cn/">Simplified Chinese</a>, <a href="/blog/2018/08/one-point-zero-zh_tw/">Traditional Chinese</a>, <a href="/blog/2018/08/one-point-zero-es/">Spanish</a>
 ~~~
 
 The much anticipated 1.0 release of [Julia](https://julialang.org) is the culmination of
@@ -13,9 +14,7 @@ celebrated the event with a reception where the community officially [set the ve
 1.0.0 together](https://www.youtube.com/watch?v=1jN5wKvN-Uk#t=3850). The release was accompanied by a
 talk: [*A brief history and wild speculation about the future of Julia*](/assets/blog/2018-08-08-one-point-zero/release-1.0-keynote.pdf).
 
-Julia was [first publicly
-announced](/blog/2012/02/why-we-created-julia) with a number of strong
-demands on the language:
+Julia was [first publicly announced](/blog/2012/02/why-we-created-julia) with a number of strong demands on the language:
 
 > We want a language that’s open source, with a liberal license. We want the speed of C with
 > the dynamism of Ruby. We want a language that’s homoiconic, with true macros like Lisp,
@@ -25,26 +24,19 @@ demands on the language:
 > together as the shell. Something that is dirt simple to learn, yet keeps the most serious
 > hackers happy. We want it interactive and we want it compiled.
 
+
+
 A vibrant and thriving community has grown up around this language, with people from all
 around the world iteratively refining and shaping Julia in pursuit of that goal. Over 700
 people have contributed to Julia itself and even more people have made thousands of amazing
 open source Julia packages. All told, we have built a language that is:
 
-* **Fast**: Julia was designed from the beginning for high performance. Julia programs
-  compile to efficient native code for multiple platforms via LLVM.
-* **General**: It uses multiple dispatch as a paradigm, making it easy to express many
-  object-oriented and functional programming patterns. The standard library provides
-  asynchronous I/O, process control, logging, profiling, a package manager, and more.
-* **Dynamic**: Julia is dynamically-typed, feels like a scripting language, and has good
-  support for interactive use.
-* **Technical**: It excels at numerical computing with a syntax that is great for math, many
-  supported numeric data types, and parallelism out of the box. Julia's multiple dispatch
-  is a natural fit for defining number and array-like data types.
-* **Optionally typed**: Julia has a rich language of descriptive data types, and type
-  declarations can be used to clarify and solidify programs.
-* **Composable**: Julia’s packages naturally work well together. Matrices of unit
-  quantities, or data table columns of currencies and colors, just work — and with good
-  performance.
+* **Fast**: Julia was designed from the beginning for high performance. Julia programs compile to efficient native code for multiple platforms via LLVM.
+* **General**: It uses multiple dispatch as a paradigm, making it easy to express many object-oriented and functional programming patterns. The standard library provides asynchronous I/O, process control, logging, profiling, a package manager, and more.
+* **Dynamic**: Julia is dynamically-typed, feels like a scripting language, and has good support for interactive use.
+* **Technical**: It excels at numerical computing with a syntax that is great for math, many supported numeric data types, and parallelism out of the box. Julia's multiple dispatch is a natural fit for defining number and array-like data types.
+* **Optionally typed**: Julia has a rich language of descriptive data types, and type declarations can be used to clarify and solidify programs.
+* **Composable**: Julia’s packages naturally work well together. Matrices of unit quantities, or data table columns of currencies and colors, just work — and with good performance.
 
 Try Julia by [downloading version 1.0 now](/downloads/). If you’re
 upgrading code from Julia 0.6 or earlier, we encourage you to first use the transitional 0.7
@@ -52,6 +44,7 @@ release, which includes deprecation warnings to help guide you through the upgra
 Once your code is warning-free, you can change to 1.0 without any functional changes. The
 registered packages are in the midst of taking advantage of this stepping stone and
 releasing 1.0-compatible updates.
+
 
 The single most significant new feature in Julia 1.0, of course, is a commitment to language
 API stability: code you write for Julia 1.0 will continue to work in Julia 1.1, 1.2, etc.
@@ -61,106 +54,31 @@ packages, tools, and new features built upon this solid foundation.
 But Julia 1.0 in not just about stability, it also introduces several new, powerful and
 innovative language features. Some of the new features since version 0.6 include:
 
-* A brand new built-in [package manager](https://docs.julialang.org/en/latest/stdlib/Pkg/)
-  brings enormous performance improvements and makes it easier than ever to install packages
-  and their dependencies. It also supports per-project package environments and recording
-  the exact state of a working application to share with others—and with your future self.
-  Finally, the redesign also introduces seamless support for private packages and package
-  repositories. You can install and manage private packages with the same tools as you’re
-  used to for the open source package ecosystem. The [presentation at
-  JuliaCon](https://www.youtube.com/watch?v=GBi__3nF-rM) provides a good overview of the new
-  design and behavior.
+* A brand new built-in [package manager](https://docs.julialang.org/en/latest/stdlib/Pkg/) brings enormous performance improvements and makes it easier than ever to install packages and their dependencies. It also supports per-project package environments and recording the exact state of a working application to share with others—and with your future self. Finally, the redesign also introduces seamless support for private packages and package repositories. You can install and manage private packages with the same tools as you’re used to for the open source package ecosystem. The [presentation at JuliaCon](https://www.youtube.com/watch?v=GBi__3nF-rM) provides a good overview of the new design and behavior.
+* Julia has a new [canonical representation for missing values](/blog/2018/06/missing). Being able to represent and work with missing data is fundamental to statistics and data science. In typical Julian fashion, the new solution is general, composable and high-performance. Any generic collection type can efficiently support missing values simply by allowing elements to include the pre-defined value `missing`. The performance of such “union-typed” collections would have been too slow in previous Julia versions, but compiler improvements now allow Julia to match the speed of custom C or C++ missing data representations in other systems, while also being far more general and flexible.
+* The built-in `String` type can now safely hold arbitrary data. Your program won’t fail hours or days into a job because of a single stray byte of invalid Unicode. All string data is preserved while indicating which characters are valid or invalid, allowing your applications to safely and conveniently work with real world data with all of its inevitable imperfections.
+* Broadcasting is already a core language feature with convenient syntax—and it’s now more powerful than ever. In Julia 1.0 it’s simple to [extend broadcasting to custom types](/blog/2018/05/extensible-broadcast-fusion) and implement efficient optimized computations on GPUs and other vectorized hardware, paving the way for even greater performance gains in the future.
+* Named tuples are a new language feature which make representing and accessing data by name efficient and convenient. You can, for example, represent a row of data as `row = (name="Julia", version=v"1.0.0", releases=8)` and access the `version` column as `row.version` with the same performance as the less convenient `row[2]`.
+* The dot operator can now be overloaded, allowing types to use the `obj.property` syntax for meanings other than getting and setting struct fields. This is especially useful for smoother interop with class-based languages such as Python and Java. Property accessor overloading also allows the syntax for getting a column of data to match named tuple syntax: you can write `table.version` to access the `version` column of a table just as `row.version` accesses the `version` field of a single row.
+* Julia’s optimizer has gotten smarter in more ways than we can list here, but a few highlights are worth mentioning. The optimizer can now propagate constants through function calls, allowing much better dead-code elimination and static evaluation than before. The compiler is also much better at avoiding allocation of short-lived wrappers around long-lived objects, which frees programmers to use convenient high-level abstractions without performance costs.
+* Parametric type constructors are now always called with the same syntax as they are declared. This eliminates an obscure but confusing corner of language syntax.
+* The iteration protocol has been completely redesigned to make it easier to implement many kinds of iterables. Instead of defining methods of three different generic functions—`start`, `next`, `done`—one now defines one- and two-argument methods of the `iterate` function. This often allows iteration to be conveniently defined with a single definition with a default value for the start state. More importantly, it makes it possible to implement iterators that only know if they're done once they've tried and failed to produce a value. These kinds of iterators are ubiquitous in I/O, networking, and producer/consumer patterns; Julia can now express these iterators in a straightforward and correct manner.
+* Scope rules have been simplified. Constructs that introduce local scopes now do so  consistently, regardless of whether a global binding for a name already exists or not. This eliminates the “soft/hard scope” distinction that previously existed and means that now Julia can always statically determine whether variables are local or global.
+* The language itself is significantly leaner, with many components split out into “standard library” packages that ship with Julia but aren’t part of the “base” language. If you need them, they’re an import away (no installation required) but they’re no longer forced on you. In the future, this will also allow standard libraries to be versioned and upgraded independently of Julia itself, allowing them to evolve and improve at a faster rate.
+* We’ve done a thorough review of all of Julia’s APIs to improve consistency and usability. Many obscure legacy names and inefficient programming patterns have been renamed or refactored to more elegantly match Julia's capabilities. This has prompted changes to make working with collections more consistent and coherent, to ensure that argument ordering follows a consistent standard throughout the language, and to incorporate (the now faster) keyword arguments into APIs where appropriate.
+* A number of new external packages are being built specifically around the new capabilities of Julia 1.0. For example:
+  * The data processing and manipulation ecosystem is being revamped to take advantage of the new missingness support.
+  * [Cassette.jl](https://github.com/jrevels/Cassette.jl) provides a powerful mechanism to inject code-transformation passes into Julia’s compiler, enabling post-hoc analysis and extension of existing code. Beyond instrumentation for programmers like profiling and debugging, this can even implement automatic differentiation for machine learning tasks.
+  * Heterogeneous architecture support has been greatly improved and is further decoupled from the internals of the Julia compiler. Intel KNLs just work in Julia. Nvidia GPUs are programmed using the [CUDANative.jl](https://github.com/JuliaGPU/CUDAnative.jl) package, and a port to Google TPUs is in the works.
 
-* Julia has a new [canonical representation for missing
-  values](/blog/2018/06/missing). Being able to represent and work with
-  missing data is fundamental to statistics and data science. In typical Julian fashion, the
-  new solution is general, composable and high-performance. Any generic collection type can
-  efficiently support missing values simply by allowing elements to include the pre-defined
-  value `missing`. The performance of such “union-typed” collections would have been too
-  slow in previous Julia versions, but compiler improvements now allow Julia to match the
-  speed of custom C or C++ missing data representations in other systems, while also being
-  far more general and flexible.
 
-* The built-in `String` type can now safely hold arbitrary data. Your program won’t fail
-  hours or days into a job because of a single stray byte of invalid Unicode. All string
-  data is preserved while indicating which characters are valid or invalid, allowing your
-  applications to safely and conveniently work with real world data with all of its
-  inevitable imperfections.
-
-* Broadcasting is already a core language feature with convenient syntax—and it’s now more
-  powerful than ever. In Julia 1.0 it’s simple to [extend broadcasting to custom
-  types](/blog/2018/05/extensible-broadcast-fusion) and implement
-  efficient optimized computations on GPUs and other vectorized hardware, paving the way for
-  even greater performance gains in the future.
-
-* Named tuples are a new language feature which make representing and accessing data by name
-  efficient and convenient. You can, for example, represent a row of data as `row =
-  (name="Julia", version=v"1.0.0", releases=8)` and access the `version` column as
-  `row.version` with the same performance as the less convenient `row[2]`.
-
-* The dot operator can now be overloaded, allowing types to use the `obj.property` syntax
-  for meanings other than getting and setting struct fields. This is especially useful for
-  smoother interop with class-based languages such as Python and Java. Property accessor
-  overloading also allows the syntax for getting a column of data to match named tuple
-  syntax: you can write `table.version` to access the `version` column of a table just as
-  `row.version` accesses the `version` field of a single row.
-
-* Julia’s optimizer has gotten smarter in more ways than we can list here, but a few
-  highlights are worth mentioning. The optimizer can now propagate constants through
-  function calls, allowing much better dead-code elimination and static evaluation than
-  before. The compiler is also much better at avoiding allocation of short-lived wrappers
-  around long-lived objects, which frees programmers to use convenient high-level
-  abstractions without performance costs.
-
-* Parametric type constructors are now always called with the same syntax as they are
-  declared. This eliminates an obscure but confusing corner of language syntax.
-
-* The iteration protocol has been completely redesigned to make it easier to implement many
-  kinds of iterables. Instead of defining methods of three different generic
-  functions—`start`, `next`, `done`—one now defines one- and two-argument methods of the
-  `iterate` function. This often allows iteration to be conveniently defined with a single
-  definition with a default value for the start state. More importantly, it makes it
-  possible to implement iterators that only know if they're done once they've tried and
-  failed to produce a value. These kinds of iterators are ubiquitous in I/O, networking, and
-  producer/consumer patterns; Julia can now express these iterators in a straightforward and
-  correct manner.
-
-* Scope rules have been simplified. Constructs that introduce local scopes now do so
-  consistently, regardless of whether a global binding for a name already exists or not.
-  This eliminates the “soft/hard scope” distinction that previously existed and means that
-  now Julia can always statically determine whether variables are local or global.
-
-* The language itself is significantly leaner, with many components split out into “standard
-  library” packages that ship with Julia but aren’t part of the “base” language. If you need
-  them, they’re an import away (no installation required) but they’re no longer forced on
-  you. In the future, this will also allow standard libraries to be versioned and upgraded
-  independently of Julia itself, allowing them to evolve and improve at a faster rate.
-
-* We’ve done a thorough review of all of Julia’s APIs to improve consistency and usability.
-  Many obscure legacy names and inefficient programming patterns have been renamed or
-  refactored to more elegantly match Julia's capabilities. This has prompted changes to make
-  working with collections more consistent and coherent, to ensure that argument ordering
-  follows a consistent standard throughout the language, and to incorporate (the now faster)
-  keyword arguments into APIs where appropriate.
-
-* A number of new external packages are being built specifically around the new capabilities
-  of Julia 1.0. For example:
-
-    * The data processing and manipulation ecosystem is being revamped to take advantage of the new missingness support. <!-- don't break these bullets with newlines... -->
-
-    * [Cassette.jl](https://github.com/jrevels/Cassette.jl) provides a powerful mechanism to inject code-transformation passes into Julia’s compiler, enabling post-hoc analysis and extension of existing code. Beyond instrumentation for programmers like profiling and debugging, this can even implement automatic differentiation for machine learning tasks.
-
-    * Heterogeneous architecture support has been greatly improved and is further decoupled from the internals of the Julia compiler. Intel KNLs just work in Julia. Nvidia GPUs are programmed using the [CUDANative.jl](https://github.com/JuliaGPU/CUDAnative.jl) package, and a port to Google TPUs is in the works.
 
 There are countless other improvements, both large and small. For a complete list of
-changes, see the [0.7 NEWS file](https://github.com/JuliaLang/julia/blob/release-0.7/NEWS.md). In our
-original [“Why We Created Julia” blog
-post](/blog/2012/02/why-we-created-julia) in 2012, we wrote
+changes, see the [0.7 NEWS file](https://github.com/JuliaLang/julia/blob/release-0.7/NEWS.md). In our original [“Why We Created Julia” blog post](/blog/2012/02/why-we-created-julia) in 2012, we wrote
 
 > It’s not complete, but it’s time for a 1.0 release—the language we’ve created is called
 > [Julia](https://julialang.org).
 
 We may have jumped the gun a bit with mentioning an impending 1.0 release, but the time has
-finally arrived and it is a heck of a release. We are truly proud of what’s been
-accomplished by the thousands of people who have contributed in so many ways to this truly
+finally arrived and it is a heck of a release. We are truly proud of what’s been accomplished by the thousands of people who have contributed in so many ways to this truly
 modern language for numerical and general programming.


### PR DESCRIPTION
Both Chinese versions are fine.

closes #912 

notes:

- item content must be on a single line (to help Julia's markdown parser)
- avoid indented blocks, always, apart from within lists environments.