### PR TITLE
advertise jill.py in Downloads as a command-line installation tool

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -56,6 +56,9 @@ Windows 7 / Windows Server 2012 users also need to install:
 
 Uninstallation is preferably performed by using the Windows uninstaller. The directory in `%HOME%/.julia` can then be deleted if you want to remove all traces of Julia (this includes user installed packages).
 
+## Cross-platform installer
+
+[Jill.py](https://github.com/johnnychen94/jill.py) is a community-maintained command-line tool that automates the installation workflow for all platforms. After installing this using `pip install jill -U`, you can then use `jill install` to install the current stable release, and `jill install latest` to install the nightly builds.
 
 ## macOS
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -56,9 +56,6 @@ Windows 7 / Windows Server 2012 users also need to install:
 
 Uninstallation is preferably performed by using the Windows uninstaller. The directory in `%HOME%/.julia` can then be deleted if you want to remove all traces of Julia (this includes user installed packages).
 
-## Cross-platform installer
-
-[Jill.py](https://github.com/johnnychen94/jill.py) is a community-maintained command-line tool that automates the installation workflow for all platforms. After installing this using `pip install jill -U`, you can then use `jill install` to install the current stable release, and `jill install latest` to install the nightly builds.
 
 ## macOS
 
@@ -107,7 +104,9 @@ Apart from this, there are several ways through which you can change environment
 
 Julia installs all its files in a single directory. Deleting the directory where Julia was installed is sufficient. If you would also like to remove your packages, remove `~/.julia`. The startup file is at `~/.julia/config/startup.jl` and the history at `~/.julia/logs/repl_history.jl`.
 
+## Cross-platform installer
 
+[Jill.py](https://github.com/johnnychen94/jill.py) is a community-maintained command-line tool that automates the installation workflow for all platforms. After installing this using `pip install jill -U`, you can then use `jill install` to install the current stable release, and `jill install latest` to install the nightly builds.
 
 # Platform Specific Instructions for Unofficial Binaries
 


### PR DESCRIPTION
[jill.py](https://github.com/johnnychen94/jill.py) is a command-line tool (written in Python) that downloads and extracts official binaries, and makes symlinks for all platforms. This could serve as a recommended alternatives to package managers such as `apt`, `brew` and `choco`

There are many sub-commands, but the most useful one is `install`:

`jill install [VERSION] [--install_dir INSTALL_DIR] [--symlink_dir SYMLINK_DIR] [--upstream UPSTREAM] [--confirm]`

demo:

![](https://github.com/johnnychen94/jill.py/raw/master/screenshots/install_demo.png)

Notes:

* `jill` host a [list of binary mirrors](https://github.com/johnnychen94/jill.py/blob/master/jill/config/sources.json), so it doesn't always download Julia from official buckets. There's a gpg verification after downloading so I think it's safe to do so. To ensure downloading from official buckets, `jill install --upstream Official` can be used.
* This package is mostly developed and maintained by myself, I'm not very sure if this is appropriate to advertise this unofficial tool. I could move this project to JuliaLang and make modifications if it is desired.

cc: @staticfloat 