### PR TITLE
Update Windows PATH instructions

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -35,7 +35,7 @@ To invoke Julia by simply typing `julia` in the command line, the Julia executab
 1.  Open Run (Windows Key + R),  type in `rundll32 sysdm.cpl,EditEnvironmentVariables` and hit enter.
 2.  In the System Variables window, highlight Path, and click Edit.
 3.  In the Edit System Variables window, move the cursor to the end of the field.
-4.  If there is no semicolon at the end, add it and paste in the path to the `bin` folder within the installation directory noted earlier. This path should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia\Julia 1.5.0\bin`.
+4.  If there is no semicolon at the end, add it and paste in the path to the `bin` folder within the installation directory noted earlier. This path should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia 1.5.0\bin`.
 5.  Click OK. You can now run Julia from the command line, by typing `julia`!
 @@
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -25,7 +25,7 @@ To invoke Julia by simply typing `julia` in the command line, the Julia executab
 @@tight-list
 1.  Open Run (Windows Key + R),  type in `rundll32 sysdm.cpl,EditEnvironmentVariables` and hit enter.
 2.  Under either the "User Variables" or "System Variables" section, find the row with "Path", and click edit.
-3.  The "Edit environment variable" UI will appear. Here, click "New", and paste in the path to the `\bin` folder within the installation directory noted earlier. This path should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia\Julia 1.5.0\bin`.
+3.  The "Edit environment variable" UI will appear. Here, click "New", and paste in the path to the `\bin` folder within the installation directory noted earlier. This path should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia 1.5.0\bin`.
 4.  Click OK. You can now run Julia from the command line, by typing `julia`!
 @@
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -14,7 +14,7 @@ Julia is available for Windows 7 and later for both 32 bit and 64 bit versions.
 ### Installation Notes
 @@tight-list
 1.  Download the Windows Julia installer from https://julialang.org/downloads/. Note, the 32-bit Julia binaries work on both 32-bit and 64-bit Windows  (x86 and x86\_64), but the 64-bit Julia binaries only run on 64-bit Windows (x86\_64).
-2. Run the installer and note the installation directory. The installation directory should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia 1.5.0`, *please note this path*. 
+2. Run the installer and note the installation directory. The installation directory should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia\Julia 1.5.0`, *please note this path*. 
 @@
 
 To invoke Julia by simply typing `julia` in the command line, the Julia executable directory needs to be added to PATH. Perform the following steps to add Julia to PATH.
@@ -25,7 +25,7 @@ To invoke Julia by simply typing `julia` in the command line, the Julia executab
 @@tight-list
 1.  Open Run (Windows Key + R),  type in `rundll32 sysdm.cpl,EditEnvironmentVariables` and hit enter.
 2.  Under either the "User Variables" or "System Variables" section, find the row with "Path", and click edit.
-3.  The "Edit environment variable" UI will appear. Here, click "New", and paste in the directory noted from the installation stage. This should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia 1.5.0\bin`
+3.  The "Edit environment variable" UI will appear. Here, click "New", and paste in the path to the `\bin` folder within the installation directory noted earlier. This path should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia\Julia 1.5.0\bin`.
 4.  Click OK. You can now run Julia from the command line, by typing `julia`!
 @@
 
@@ -35,7 +35,7 @@ To invoke Julia by simply typing `julia` in the command line, the Julia executab
 1.  Open Run (Windows Key + R),  type in `rundll32 sysdm.cpl,EditEnvironmentVariables` and hit enter.
 2.  In the System Variables window, highlight Path, and click Edit.
 3.  In the Edit System Variables window, move the cursor to the end of the field.
-4.  If there is no semicolon at the end, add it and paste in the text you copied into the notepad. This should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia 1.5.0\bin`
+4.  If there is no semicolon at the end, add it and paste in the path to the `bin` folder within the installation directory noted earlier. This path should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia\Julia 1.5.0\bin`.
 5.  Click OK. You can now run Julia from the command line, by typing `julia`!
 @@
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -14,7 +14,7 @@ Julia is available for Windows 7 and later for both 32 bit and 64 bit versions.
 ### Installation Notes
 @@tight-list
 1.  Download the Windows Julia installer from https://julialang.org/downloads/. Note, the 32-bit Julia binaries work on both 32-bit and 64-bit Windows  (x86 and x86\_64), but the 64-bit Julia binaries only run on 64-bit Windows (x86\_64).
-2. Run the installer and note the installation directory. The installation directory should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia\Julia 1.5.0`, *please note this path*. 
+2. Run the installer and note the installation directory. The installation directory should look something like `C:\Users\JohnDoe\AppData\Local\Programs\Julia 1.5.0`, *please note this path*. 
 @@
 
 To invoke Julia by simply typing `julia` in the command line, the Julia executable directory needs to be added to PATH. Perform the following steps to add Julia to PATH.


### PR DESCRIPTION
I installed Julia 1.4.2 recently and the directory that contains `julia.exe` looks like this: 
`C:\Users\username\AppData\Local\Programs\Julia\Julia-1.4.2\bin`, not 
 `C:\Users\username\AppData\Local\Programs\Julia-1.4.2\bin` 
(the website currently says that the latter is what the directory should look like). Furthermore, the directions on the current page says "paste in the directory noted from the installation stage", but the directory noted from the installation stage **does not include the \bin**, which is confusing, because the example path provided immediately afterwards *does include* a `\bin` at the end. I've edited the language to be a bit more clear.

## Screenshot of webpage with explanation
![image](https://user-images.githubusercontent.com/5581093/88720725-2f1b7d00-d0da-11ea-8087-2522633be10e.png)
