### PR TITLE
RFC: Put the musl/glibc remark on the download page

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -215,7 +215,7 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
 
 {{end}} <!-- upcoming_release -->
 
-(*) Most users would prefer the `glibc` version of the distribution unless you know that your system uses `musl`.
+(*) Most Linux users should use the glibc binaries unless you know that your system uses musl as its libc.
 
 ## Older Releases
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -172,7 +172,7 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
     <tr>
       <th> Generic Linux on x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3">
-        <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz">64-bit (glibc)</a>
+        <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz">64-bit (glibc*)</a>
         (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz.asc">GPG</a>),
         <a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz">64-bit (musl)</a>
         (<a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz.asc">GPG</a>)
@@ -215,6 +215,7 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
 
 {{end}} <!-- upcoming_release -->
 
+(*) Most users would prefer the `glibc` version of the distribution unless you know that your system uses `musl`.
 
 ## Older Releases
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -174,7 +174,7 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
       <td colspan="3">
         <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz">64-bit (glibc)</a>
         (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz.asc">GPG</a>),
-        <a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz">64-bit (musl*)</a>
+        <a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz">64-bit (musl)</a><sup>[<a href=#musl-fn>1</a>]</sup>
         (<a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz.asc">GPG</a>)
       </td>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-i686.tar.gz">32-bit</a>
@@ -215,7 +215,12 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
 
 {{end}} <!-- upcoming_release -->
 
-(*) Most Linux users should use the glibc binaries unless you know that your system uses musl as its libc.
+
+\label{musl-fn}
+~~~
+<sup>[1]</sup>
+~~~
+Most Linux users should use the glibc binaries unless you know that your system uses musl as its libc.
 
 ## Older Releases
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -172,9 +172,9 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
     <tr>
       <th> Generic Linux on x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3">
-        <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz">64-bit (glibc*)</a>
+        <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz">64-bit (glibc)</a>
         (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz.asc">GPG</a>),
-        <a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz">64-bit (musl)</a>
+        <a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz">64-bit (musl*)</a>
         (<a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz.asc">GPG</a>)
       </td>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-i686.tar.gz">32-bit</a>


### PR DESCRIPTION
I love the remark about musl/glibc on the downloads/platform page, but I think it is a bit too hidden. This PR tries to put it directly on the downloads page. I tried a good old footenote, but I don' t know if I am doing this right or if it is the right approach.

I just wanted to get this moving, since I don't think a user should be required to know what glibc or musl is in order to download julialang. If a user has to leave the downloads page in order to google for more information for his system, the installation is too complicated :) 