### PR TITLE
Make HTML redirect a helper function

### DIFF
--- a/blog/2017/12/ml&pl-cn.html
+++ b/blog/2017/12/ml&pl-cn.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2017/12/ml-pl-cn/" />
-  </head>
-</html>
+{{redirect /blog/2017/12/ml-pl-cn/}}

--- a/blog/2017/12/ml&pl-zh_tw.html
+++ b/blog/2017/12/ml&pl-zh_tw.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2017/12/ml-pl-zh/" />
-  </head>
-</html>
+{{redirect /blog/2017/12/ml-pl-zh/}}

--- a/blog/2017/12/ml&pl.html
+++ b/blog/2017/12/ml&pl.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/blog/2017/12/ml-pl/" />
-  </head>
-</html>
+{{redirect /blog/2017/12/ml-pl/}}

--- a/download.html
+++ b/download.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/downloads/">
-  </head>
-</html>
+{{redirect /downloads/}}

--- a/ecosystems.html
+++ b/ecosystems.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/community/" />
-  </head>
-</html>
+{{redirect /community/}}

--- a/license.html
+++ b/license.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=https://github.com/JuliaLang/julia/blob/master/LICENSE.md">
-  </head>
-</html>
+{{redirect https://github.com/JuliaLang/julia/blob/master/LICENSE.md}}

--- a/manual.html
+++ b/manual.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=https://docs.julialang.org/en/v1/">
-  </head>
-</html>
+{{redirect https://docs.julialang.org/}}

--- a/soc/ideas-page.html
+++ b/soc/ideas-page.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/jsoc/">
-  </head>
-</html>
+{{redirect /jsoc/}}

--- a/soc/index.html
+++ b/soc/index.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/jsoc/">
-  </head>
-</html>
+{{redirect /jsoc/}}

--- a/teaching.html
+++ b/teaching.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=/learning/">
-  </head>
-</html>
+{{redirect /learning/}}

--- a/utf8proc.html
+++ b/utf8proc.html
@@ -1,7 +1,1 @@
-<!-- REDIRECT -->
-<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=https://juliastrings.github.io/utf8proc/">
-  </head>
-</html>
+{{redirect https://juliastrings.github.io/utf8proc/}}

--- a/utils.jl
+++ b/utils.jl
@@ -121,3 +121,21 @@ function hfun_recentblogposts()
     end
     return String(take!(io))
 end
+
+"""
+    {{redirect url}}
+
+Creates a HTML layout for a redirect to `url`.
+"""
+function hfun_redirect(url)
+    s = """
+    <!-- REDIRECT -->
+    <!doctype html>
+    <html>
+      <head>
+        <meta http-equiv="refresh" content="0; url=$(url[1])">
+      </head>
+    </html>
+    """
+    return s
+end


### PR DESCRIPTION
All links are identical except the one in `manual.html`. It used to be https://docs.julialang.org/en/v1/, but I changed it to https://docs.julialang.org for automatic redirect. That will make the link work for v2 too, I guess?

Idea from [sciml.ai](https://github.com/SciML/sciml.ai/blob/master/utils.jl#L68).