### PR TITLE
Properly scale images on Learning page

### DIFF
--- a/learning/index.md
+++ b/learning/index.md
@@ -82,9 +82,9 @@
      </p>
      <p>We also have a growing number of curated Julia courses available through <a href="https://juliaacademy.com/courses">JuliaAcademy</a>.</p>
      <a href="https://juliaacademy.com/courses">
-     <img src="assets/JA-1.png" alt="JuliaAcademy" width="600" height="200" class="center">
-     <img src="assets/JA-2.png" alt="JuliaAcademy" width="600" height="200" class="center">
-     <img src="assets/JA-3.png" alt="JuliaAcademy" width="600" height="200" class="center">
+     <img src="assets/JA-1.png" alt="JuliaAcademy" class="img-fluid">
+     <img src="assets/JA-2.png" alt="JuliaAcademy" class="img-fluid">
+     <img src="assets/JA-3.png" alt="JuliaAcademy" class="img-fluid">
      </a>
    </div>
  </div>
@@ -108,7 +108,7 @@
     <br>
 
     <p>Interested in getting a Julia book? Check out the <a href="books/">amazing books members of our community has written</a> since Julia was created.</p>
-    <img src="assets/books.png" alt="Julia book collection" width="600" height="450" class="center">
+    <img src="assets/books.png" alt="Julia book collection" class="img-fluid">
   </div>
   <br><br>
 </div>
@@ -131,7 +131,7 @@
      This page puts together various resources that instructors and students alike may find useful.
      See <a href="classes/">where Julia is being taught today</a>.
      </p>
-     <img src="assets/schools.png" alt="Collection of schools where Julia is taught" width="600" height="450" class="center">
+     <img src="assets/schools.png" alt="Collection of schools where Julia is taught" class="img-fluid">
    </div>
  </div>
 <br>


### PR DESCRIPTION
Using "center" class conflicts with defined width, while fixed width and height are bad for mobile devices. Both can be replaced with "img-fluid" class which scales the images appropriately.