### PR TITLE
Fix path reference issue on MacOS

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -67,10 +67,10 @@ Navigate to `/usr/local/bin` and remove the `julia` file. Then type the followin
 
 
 ```
-ln -s /Applications/Julia-{{stable_release}}.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
+ln -s /Applications/Julia-{{stable_release_short}}.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia
 ```
 
-which creates a symlink to a Julia version (here {{stable_release}}) of your choosing.
+which creates a symlink to a Julia version (here {{stable_release_short}}) of your choosing.
 Once that is done, you can close the shell profile page and quit Terminal. Now, just simply open Terminal again, type in `julia` in it, and it should run your version of Julia!
 
 You can uninstall Julia by deleting Julia.app and the packages directory in `~/.julia`. Multiple Julia.app binaries can co-exist without interfering with each other. If you would also like to remove your preferences files, remove `~/.juliarc.jl` and `~/.julia_history`.


### PR DESCRIPTION
stable_release substitutes with patch # so this instruction

`ln -s /Applications/Julia-1.5.0.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia`

on https://julialang.org/downloads/platform/#macos is incorrect--the right path is `.../Julia-1.5.app/...`, at least on my MacOS Catalina machine.

Kudos @fredrikekre for solution.

https://github.com/JuliaLang/www.julialang.org/issues/956