### PR TITLE
update of deploy script and minor fixes, see also #969

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.3.0
+          version: 1.5.0
       # This ensures that NodeJS and Franklin are loaded then it installs
       # highlight.js which is needed for the prerendering step.
       # Then the environment is activated and instantiated to install all
@@ -47,7 +47,7 @@ jobs:
         run: julia -e '
               using Pkg;
               Pkg.add("NodeJS");
-              Pkg.add(PackageSpec(name="Franklin",version="0.8"));
+              Pkg.add(PackageSpec(name="Franklin",version="0.9"));
               using NodeJS; run(`$(npm_cmd()) install highlight.js`);
               using Franklin; optimize();
               cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"))'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 Manifest.toml
 Project.toml
 package-lock.json
+.__py_*

--- a/blog/2020/05/jsoc-gsoc2020.md
+++ b/blog/2020/05/jsoc-gsoc2020.md
@@ -5,35 +5,32 @@
 @def rss = """GSoC and JSoC 2020 Project List"""
 
 
-This summer, the Julia Language will be hosting students through GSoC and JSoC. You can read more about this by checking out [our Discourse post](https://discourse.julialang.org/t/julia-seasons-of-contributions-to-supplement-gsoc-2020/38754). We are very excited to have 25 students working with us. Here are the projects they will be working on: 
+This summer, the Julia Language will be hosting students through GSoC and JSoC. You can read more about this by checking out [our Discourse post](https://discourse.julialang.org/t/julia-seasons-of-contributions-to-supplement-gsoc-2020/38754). We are very excited to have 25 students working with us. Here are the projects they will be working on:
 
-| Display Name        | Project   |
-| ------------- |:-------------:|
-| Sharan Yalburgi      | 	Adding GPML capabilities to JuliaGaussianProcesses |
+| Display Name   | Project   |
+| :------------- | :---------|
+| Sharan Yalburgi  | 	Adding GPML capabilities to JuliaGaussianProcesses |
 | Arthur Lui      | BNP Benchmarks and Feature Comparisons for Turing and Other PPLs      |
-| Nirmal Praveen Suthar | Deep Learning for 3D Computer Vision  | 
-| Alexander Seiler | General Improvements for LinearMaps.jl      | 
-| Kirill Zubov | General partial differential equation solver using neural networks with ModelingToolkit interface      | 
+| Nirmal Praveen Suthar | Deep Learning for 3D Computer Vision  |
+| Alexander Seiler | General Improvements for LinearMaps.jl      |
+| Kirill Zubov | General partial differential equation solver using neural networks with ModelingToolkit interface      |
 | frankschae | High weak order stochastic differential equation solvers and their utility in neural stochastic differential equations     |
-| Koustav Chowdhury | Implementation of a hash table based on SwissTable and adding Trees.jl to JuliaCollections      | 
-| MartinuzziFrancesco | Implementation of a Reservoir Computing library for timeseries prediction      | 
-| Tejas Vaidhya | Implementing ALBERT in julia      | 
-| Ludovico Bessi | Improving Surrogates.jl      | 
-| Peter Cheng | Leveraging Hugging Face Transformers package in Julia      | 
-| Aadesh Deshmukh | MLJTime - Adding Time Series Support For MLJ      | 
-| Utkarsh530 | Performance Enhancements and Optimizations for Differential Equation solvers      | 
-| Saranjeet Kaur Bhogal | Polychord Nested Sampling Algorithm Building and Integration with Turing in Julia      | 
-| Uziel Linares | Taylor models and a guaranteed ODE solver      | 
-| Chen Zhao | ZX.jl: ZX-calculus for Julia      | 
-| Arsh Sharma | A Geospatial Data handling package for Julia      | 
-| Krish Agarwal | A Standards compliant Interval Arithmetic Library      | 
-| SebastianGuadalupe | Computational Methods using Zonotopes      | 
-| Nabanita Dash | Fast communication library in Julia by wrapping the UCX networking library      | 
-| Ashrya Agrawal-1 | MLJ - FairML      | 
-| SebastianM-C | N-body problem tooling for large scale electrodynamics simulations      | 
-| Ashutosh Bharambe | Neural Networks for solving differential equations      | 
-| Abhinav Mehndiratta | Parallel Graph Algorithms      | 
-| abhinav_gupta | Parameter estimation for nonlinear dynamical models.      | 
-
-
-
+| Koustav Chowdhury | Implementation of a hash table based on SwissTable and adding Trees.jl to JuliaCollections      |
+| MartinuzziFrancesco | Implementation of a Reservoir Computing library for timeseries prediction      |
+| Tejas Vaidhya | Implementing ALBERT in julia      |
+| Ludovico Bessi | Improving Surrogates.jl      |
+| Peter Cheng | Leveraging Hugging Face Transformers package in Julia      |
+| Aadesh Deshmukh | MLJTime - Adding Time Series Support For MLJ      |
+| Utkarsh530 | Performance Enhancements and Optimizations for Differential Equation solvers      |
+| Saranjeet Kaur Bhogal | Polychord Nested Sampling Algorithm Building and Integration with Turing in Julia      |
+| Uziel Linares | Taylor models and a guaranteed ODE solver      |
+| Chen Zhao | ZX.jl: ZX-calculus for Julia      |
+| Arsh Sharma | A Geospatial Data handling package for Julia      |
+| Krish Agarwal | A Standards compliant Interval Arithmetic Library      |
+| SebastianGuadalupe | Computational Methods using Zonotopes      |
+| Nabanita Dash | Fast communication library in Julia by wrapping the UCX networking library      |
+| Ashrya Agrawal-1 | MLJ - FairML      |
+| SebastianM-C | N-body problem tooling for large scale electrodynamics simulations      |
+| Ashutosh Bharambe | Neural Networks for solving differential equations      |
+| Abhinav Mehndiratta | Parallel Graph Algorithms      |
+| abhinav_gupta | Parameter estimation for nonlinear dynamical models.      |

--- a/learning/index.md
+++ b/learning/index.md
@@ -1,3 +1,4 @@
+@def title="Get started with Julia"
 
 ~~~
 <!--


### PR DESCRIPTION
Closes #969 and a few minor updates and fixes.

**Note**: for onlookers, pages that are full HTML like `learning.md` should still have a `@def title ...` otherwise you get a warning (and the tab won't be named properly). 

I'll merge this myself as this is pretty urgent given that people running stuff locally would fail to see the blogs properly rendered. 