### PR TITLE
Fix URL in MIT announcement banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div class="alert alert-dark alert-dismissible mb-0" role="alert">
       <!-- Only this <p> element should be changed in an alert -->
       <p class="text-center">
-	      Check out Grant Sanderson (3Blue1Brown), Alan Edelman, David Sanders and James Schloss <a href="https://computationalthinking.mit.edu/fall20/">teaching Julia at MIT</a>
+	      Check out Grant Sanderson (3Blue1Brown), Alan Edelman, David Sanders and James Schloss <a href="https://computationalthinking.mit.edu/Fall20/">teaching Julia at MIT</a>
       </p>
       <!-- Nothing more! -->
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">


### PR DESCRIPTION
The link in the banner on https://julialang.org/ leads to a 404 page: https://computationalthinking.mit.edu/fall20/

The correct URL is https://computationalthinking.mit.edu/Fall20/ with an upper case F, I think.

(This may be a mistake on their end too, I don't know)