### PR TITLE
Use Franklin 0.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.5.0
+          version: 1.5
       # This ensures that NodeJS and Franklin are loaded then it installs
       # highlight.js which is needed for the prerendering step.
       # Then the environment is activated and instantiated to install all
@@ -47,7 +47,7 @@ jobs:
         run: julia -e '
               using Pkg;
               Pkg.add("NodeJS");
-              Pkg.add(PackageSpec(name="Franklin",version="0.9"));
+              Pkg.add(PackageSpec(name="Franklin",version="0.10"));
               using NodeJS; run(`$(npm_cmd()) install highlight.js`);
               using Franklin; optimize();
               cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"))'


### PR DESCRIPTION
updating the version in the deploy script; note that the updates from 0.9.16 -> 0.10 do not affect this website in any way

* drop of support for an old file structure (pre Franklin 0.6...)
* addition of a `@delay` macro which allows `hfun` to have pages wait for a complete full pass before being executed (relevant for `hfun` which rely e.g. on the list of page tags which is only complete after a full pass over all pages). 

so this should just be good to merge