### PR TITLE
fixing meta tags + hfun

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,20 +73,13 @@ If in doubt, after running Franklin's server, copy the content of `__site/feed.x
 
 ### Metadata
 
-In order to add `<meta ... >` tags on your blog post, add
+In order to add `<meta aaa="bbb" content="ccc">` tags on your blog post, add
 
 ```julia
-@def meta = ("prop11"=>"val11", "prop21"=>"val21")
+@def meta =[("aaa", "bbb", "ccc"),]
 ```
 
-or for multiple tags
-
-```julia
-@def meta = [("prop11"=>"val11", "prop21"=>"val21"),
-             ("prop12"=>"val12", "prop22"=>"val22")]
-```
-
-see for instance [Keno's recent blog post](https://raw.githubusercontent.com/JuliaLang/www.julialang.org/master/blog/2020/05/rr.md).
+(you can specify multiple tags of course). See for instance [Keno's recent blog post](https://raw.githubusercontent.com/JuliaLang/www.julialang.org/master/blog/2020/05/rr.md).
 
 ## Looking for broken links
 

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -37,7 +37,7 @@
   {{end}}{{end}}
 
   <!-- OGP Metadata -->
-  {{ifdef meta}}{{meta}}{{end}}
+	{{meta}}
 
 </head>
 

--- a/_layout/meta.html
+++ b/_layout/meta.html
@@ -3,6 +3,3 @@
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="author" content="Jeff Bezanson, Stefan Karpinski, Viral Shah, Alan Edelman, et al.">
 <meta name="description" content="The official website for the Julia Language. Julia is a language that is fast, dynamic, easy to use, and open source. Click here to learn more.">
-<meta property="og:title" content="The Julia Language">
-<meta property="og:image" content="/assets/images/julia-open-graph.png">
-<meta property="og:description" content="Official website for the Julia programming language">

--- a/blog/2020/05/rr.md
+++ b/blog/2020/05/rr.md
@@ -1,16 +1,18 @@
-@def authors = "Keno Fischer"
-@def published = "2 May 2020"
-@def title = "Julia 1.5 Feature Preview: Time Traveling (Linux) Bug Reporting"
++++
+authors = "Keno Fischer"
+published = "2 May 2020"
+title = "Julia 1.5 Feature Preview: Time Traveling (Linux) Bug Reporting"
+rss = """Julia 1.5 is gaining a cool new bug reporting capability, leveraging mozilla's rr project to automatically create fully-reproducible bug reports"""
+meta = [
+    ("property", "og:video", "https://julialang.org/assets/blog/2020-05-02-rr/preview.mp4"),
+		("name", "twitter:player", "https://www.youtube.com/embed/JO6Jvad3XRU"),
+		("name", "twitter:player:width", "960"),
+		("name", "twitter:player:height", "720")
+		]
++++
+
+<!-- @tlienart -- leave this here for now -->
 @def rss_pubdate = Date(2020, 5, 2)
-@def rss = """Julia 1.5 is gaining a cool new bug reporting capability, leveraging mozilla's rr project to automatically create fully-reproducible bug reports"""
-@def meta = [("property" => "og:video",
-              "content" => "https://julialang.org/assets/blog/2020-05-02-rr/preview.mp4"),
-			 ("name" => "twitter:player",
-			  "content" => "https://www.youtube.com/embed/JO6Jvad3XRU"),
-	     	 ("name" => "twitter:player:width",
-			  "content" => "960"),
-	     	 ("name" => "twitter:player:height",
-			 "content" => "720")]
 
 ~~~
   <link rel="stylesheet" type="text/css" href="/assets/blog/2020-05-02-rr/asciinema-player.css" />

--- a/blog/2020/09/rr-memory-magic.md
+++ b/blog/2020/09/rr-memory-magic.md
@@ -508,10 +508,11 @@ an invaluable tool to analyze this issue. The fact that the stray bit flip was m
 from the recording already excluded 99% of possible cases for the crash, and some
 careful analysis of the trace gave enough clues to be able to eliminate most of the
 remaining. To quote Sherlock Holmes
+
 > When you have eliminated the impossible, whatever remains, however improbable, must be the truth.
-Without `rr`, it may often
-be tempting to blame unexplained crashes on bad hardware, cosmic rays or gremlins
-living under the floors. Here, we were able to fairly convincingly conclude that
-that the issue must indeed be bad memory. I like to say that `rr` turns a debugging
-problem into a data analysis problem and here, as is so often the case, the most
+
+Without `rr`, it may often be tempting to blame unexplained crashes on bad hardware,
+cosmic rays or gremlins living under the floors. Here, we were able to fairly convincingly
+conclude that that the issue must indeed be bad memory. I like to say that `rr` turns a
+debugging problem into a data analysis problem and here, as is so often the case, the most
 insightful piece is figuring out what data is missing.

--- a/utils.jl
+++ b/utils.jl
@@ -13,13 +13,13 @@ A full example can be found in `blog/2020/05/rr.md`.
 """
 function hfun_meta()
     p = "property"
-    # default og properties, can be over-written by the user
+    # default og properties, can be overwritten by the user
     ogdflt = (
         title = (p, "og:title", "The Julia Language"),
         image = (p, "og:image", "/assets/images/julia-open-graph.png"),
         descr = (p, "og:description", "Official website for the Julia programming language"),
         )
-    # check what the user has provided (if anything) and override defaults
+    # check what the user has provided (if anything) use defaults otherwise
     meta = locvar(:meta)
     if !isnothing(meta)
         for c in keys(ogdflt)


### PR DESCRIPTION
supersedes #1004 

* improves the `hfun_meta` so that it has default values that are applied on all pages for `og:xxx` fields which can be overwritten by the user
* simplify the way `meta` tags are specified + adjust the definitions wherever they were used

Note: there's a comment about `pubdate` to leave that definition out of the `+++` block for now, this is a small bug in Franklin which I'll fix within the hour.