### PR TITLE
Fix link for Hacktoberfest Hackathon/Meetup 2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div class="alert alert-dark alert-dismissible mb-0" role="alert">
       <!-- Only this <p> element should be changed in an alert -->
       <p class="text-center">
-	      Join us for a Hacktoberfest Meetup/Hackathon this Saturday, October 10th. <a href="https://organize.mlh.io/events/4574-hacktoberfest-online-global-julia-meetup">Sign up now</a>
+	      Join us for a Hacktoberfest Meetup/Hackathon this Saturday, October 10th. <a href="https://organize.mlh.io/participants/events/4574-hacktoberfest-online-global-julia-meetup">Sign up now</a>
       </p>
 <!--       <p class="text-center">
 	      Check out Grant Sanderson (3Blue1Brown), Alan Edelman, David Sanders and James Schloss <a href="https://computationalthinking.mit.edu/Fall20/">teaching Julia at MIT</a>


### PR DESCRIPTION
Hello! The old link was giving me a 404 error even when I was logged in to MLH. I think I fixed it by putting in the correct link from [Logan Kilpatrick's Discourse post for the hackathon/meetup](https://discourse.julialang.org/t/julia-language-hacktoberfest-meetup-hackathon-t-shirts/47645).

Old Link: https://organize.mlh.io/events/4574-hacktoberfest-online-global-julia-meetup
New Link: https://organize.mlh.io/participants/events/4574-hacktoberfest-online-global-julia-meetup

The new link in this PR works for me now.

Let me know if this is the correct fix! No worries if not, in that case feel free to disregard.

Tagging @logankilpatrick for feedback