### PR TITLE
Fix for deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Install SSH Client
-        if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name # if this build is NOT a PR build, OR if this build is a PR build and the PR is NOT from a fork
-        uses: webfactory/ssh-agent@v0.2.0
-        with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
       - name: Fix URLs for PR preview deployment (pull request previews)
         if: github.event_name == 'pull_request'
         run: |
@@ -63,6 +58,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          SSH: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: __site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - name: Install SSH Client
+        if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name # if this build is NOT a PR build, OR if this build is a PR build and the PR is NOT from a fork
+        uses: webfactory/ssh-agent@v0.4.1
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
       - name: Fix URLs for PR preview deployment (pull request previews)
         if: github.event_name == 'pull_request'
         run: |
@@ -58,6 +63,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SSH: true
           BRANCH: gh-pages
           FOLDER: __site


### PR DESCRIPTION
This uses the `secrets.GITHUB_TOKEN` instead of the SSH token which should prevent https://github.com/tlienart/Franklin.jl/issues/644 from happening. 