### PR TITLE
Pin python version in github-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.x'
+          python-version: '3.8'
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
(should be safe to merge)

This pins the python version to `3.8`, python is only used in a very minor way on the website (for the magnification) so that won't change anything, however it will prevent potential CI errors with python 3.9 in the eventuality where someone were to use PyPlot and require matplotlib for instance.