### PR TITLE
Fix PR comments

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Create PR comment
         if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name # if this is a pull request build AND the pull request is NOT made from a fork
-        uses: thollander/actions-comment-pull-request@1f25fabed60c3f141743c3a522529950a8fb2191
+        uses: thollander/actions-comment-pull-request@71efef56b184328c7ef1f213577c3a90edaa4aff
         with:
           message: 'Once the build has completed, you can preview your PR at this URL: https://julialang.netlify.app/previews/PR${{ github.event.number }}/'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For posterity, fixing this is done by:
1. Go to the repo for the action in question: https://github.com/thollander/actions-comment-pull-request
2. Go to the commits: https://github.com/thollander/actions-comment-pull-request/commits/master
3. Get the latest commit

@logankilpatrick Note that previews will not be created for this PR, since it is from a fork. I'd recommend that copy the change from this PR, and then make your own PR that is not from a fork; that way we can confirm that this fixes the PR previews.