### PR TITLE
remove some links from diversity pages that lead nowhere

### DIFF
--- a/diversity/current/JuliaES.md
+++ b/diversity/current/JuliaES.md
@@ -1,1 +1,0 @@
-# Julia ES

--- a/diversity/current/index.md
+++ b/diversity/current/index.md
@@ -2,8 +2,8 @@
 
 The Julia Language community is always working on ways we can systematically promote diversity and inclusion. Here are some active projects we are working on in that vain:
 
-- [Translation of Julia materials into Spanish](/diversity/current/JuliaES/)
-- [Improving the guidance around moderation on Discourse](/diversity/current/moderation/)
-- [Actively recruiting folks from underrepresented communities to learn Julia](/diversity/current/recruitment/)
-- [Ensuring the first time contributor experience is smooth](/diversity/current/new-contributors/)
-- [Technical and career mentoring for underrepresented groups in computing](/diversity/current/mentoring/)
+- Translation of Julia materials into Spanish
+- Improving the guidance around moderation on Discourse
+- Actively recruiting folks from underrepresented communities to learn Julia
+- Ensuring the first time contributor experience is smooth
+- Technical and career mentoring for underrepresented groups in computing

--- a/diversity/current/mentoring.md
+++ b/diversity/current/mentoring.md
@@ -1,1 +1,0 @@
-# Mentoring

--- a/diversity/current/moderation.md
+++ b/diversity/current/moderation.md
@@ -1,1 +1,0 @@
-# Moderation

--- a/diversity/current/new-contributors.md
+++ b/diversity/current/new-contributors.md
@@ -1,1 +1,0 @@
-# New Contributors 

--- a/diversity/current/recruitment.md
+++ b/diversity/current/recruitment.md
@@ -1,1 +1,0 @@
-# Recruitment 

--- a/diversity/ideas/index.md
+++ b/diversity/ideas/index.md
@@ -4,4 +4,4 @@ The current team working on D&I are hyper focused on ensuring our current projec
 
 If you are interested in helping out or leading any of the below initiatives, please free to send and email to `diversity@julialang.org` or drop by the [#diversity channel on Slack](http://julialang.org/slack/).
 
-[Live ASL interpretation for JuliaCon]()
+- Live ASL interpretation for JuliaCon


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/www.julialang.org/issues/1070.

I think the list of the active projects would have more impact if they had a bit more context to them. Right now, it isn't clear if it is just a wish list or something that is actually ongoing. For example, the "Translation of Julia materials into Spanish" could have a link to where that material is.