### PR TITLE
downloads: Add link to versions.json

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -349,3 +349,9 @@ The platforms currently supported by Julia are listed below. They are divided in
 </ul>
 ~~~
 @@ @@
+
+
+
+## JSON release feed
+
+The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json). The file is updated once every 24 hours.

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -354,4 +354,4 @@ The platforms currently supported by Julia are listed below. They are divided in
 
 ## JSON release feed
 
-The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json). The file is updated once every 24 hours.
+The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json) ([schema](https://github.com/SaschaMann/Julia-versions.json/blob/main/schema.json)). The file is updated once every 24 hours.


### PR DESCRIPTION
This file contains info on all published Julia versions (see https://github.com/JuliaLang/julia/issues/33817 for more context).
It's currently not easy to find but may be useful for people who build Julia tooling.

Generation script: https://github.com/SaschaMann/Julia-versions.json/blob/main/build_json_map.jl (written by `@staticfloat`)
Repo that builds and deploys it: https://github.com/SaschaMann/Julia-versions.json

---

I don't really know where this belongs on the page, so I just added it to the end. Let me know if I should move it elsewhere.