### PR TITLE
Update platform.md

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -155,7 +155,7 @@ sudo yum install julia
 If you are using CentOS (version 7 or higher), directly run:
 
 ```shell
-sudo yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo
+sudo yum-config-manager --add https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo
 sudo yum install julia
 ```
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -154,8 +154,10 @@ sudo yum install julia
 
 If you are using CentOS (version 7 or higher), directly run:
 
-sudo yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo
+```shell
+sudo yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo
 sudo yum install julia
+```
 
 If both `dnf` and `yum-config-manager` are not available for your distribution, download the relevant `.repo` file from the Copr webpage, copy it to `/etc/yum.repos`, and run the second command.
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -155,7 +155,7 @@ sudo yum install julia
 If you are using CentOS (version 7 or higher), directly run:
 
 ```shell
-sudo yum-config-manager --add https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo
+sudo yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo
 sudo yum install julia
 ```
 


### PR DESCRIPTION
Some missing dashes and an equal sign make the CentOS (version 7 or higher) install commands incorrect. I fixed the formatting, and the commands work. The main place to look is at "-add-repo " should have been "--add-repo="

incorrect:
sudo yum-config-manager –add-repo https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo

corrected:
sudo yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/nalimilan/julia/repo/epel-7/nalimilan-julia-epel-7.repo