### PR TITLE
Fix the welcome message

### DIFF
--- a/.github/workflows/greet.yml
+++ b/.github/workflows/greet.yml
@@ -2,7 +2,7 @@ name: Welcome first time contributors
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     branches:
       - master
 jobs:


### PR DESCRIPTION
When GitHub Actions runs on the `pull_request` event on a pull request from a fork, the `GITHUB_TOKEN` has read-only permissions, and thus it will not be able to post a comment. See e.g. https://github.com/JuliaLang/www.julialang.org/pull/1108, where the welcome message failed on commit `60bff9b`, and no comment was posted.

Instead, we should use the `pull_request_target` event, which should have the correct permissions even when the pull request is from a fork.

@SaschaMann Can you take a look at this PR and confirm that I am using `pull_request_target` correctly?