### PR TITLE
Add link to the JuliaPackages project

### DIFF
--- a/packages/index.md
+++ b/packages/index.md
@@ -4,6 +4,7 @@ The Julia ecosystem contains over 4,000 packages that are registered in the [Gen
 
 @@tight-list
 * [JuliaHub](https://juliahub.com) — a [Julia Computing](https://juliacomputing.com) service that includes search of all registered open source package documentation, code search, and navigation by tags/keywords. It is powered by [Julia Team](https://juliacomputing.com/products/juliateam). 
-* [JuliaObserver](https://juliaobserver.com) — see what packages are popular and/or trending, navigate by package categories.
+* [Julia Observer](https://juliaobserver.com) — see what packages are popular and/or trending, navigate by package categories.
+* [Julia Packages](https://juliapackages.com) — browse Julia packages, filter by categories, and sort them by popularity, creation date or date of last update. Also supports browsing package developers.
 * [Julia.jl](https://github.com/svaksha/Julia.jl) — a manually curated taxonomy of Julia packages (category information for JuliaPackages is derived from this as well).
 @@


### PR DESCRIPTION
Also add a space in the name of the "Julia Observer" project, matching how the project presents itself.