### PR TITLE
Remove 'soc' directory

### DIFF
--- a/soc/ideas-page.html
+++ b/soc/ideas-page.html
@@ -1,1 +1,0 @@
-{{redirect /jsoc/}}

--- a/soc/index.html
+++ b/soc/index.html
@@ -1,1 +1,0 @@
-{{redirect /jsoc/}}


### PR DESCRIPTION
Seems like this directory is no longer used? It's presence confused me when trying to make changes. 