### PR TITLE
Update platform.md macos homebrew syntax changes

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -137,7 +137,7 @@ Chocolatey automatically creates a shim for the Julia executable, so you simply 
 Julia can be installed using the [Homebrew package manager](https://brew.sh/) as follows:
 
 ```shell
-brew cask install julia
+brew install julia
 ```
 
 This automatically puts the binary into a directory in the user's PATH, so you can simply type `julia` to run Julia in the terminal.

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -134,10 +134,10 @@ Chocolatey automatically creates a shim for the Julia executable, so you simply 
 
 ## HomeBrew on Mac
 
-Julia can be installed using the [Homebrew package manager](https://brew.sh/) as follows:
+Julia can be installed using the [Homebrew package manager](https://formulae.brew.sh/cask/julia) as follows:
 
 ```shell
-brew install julia
+brew install --cask julia
 ```
 
 This automatically puts the binary into a directory in the user's PATH, so you can simply type `julia` to run Julia in the terminal.


### PR DESCRIPTION
brew cask <command> was deprecated in favor of brew <command> --cask in Homebrew 2.6.0. Starting with 2.7.0 they have been removed in favor of brew <command>