### PR TITLE
Update distributed training GSoC

### DIFF
--- a/jsoc/gsoc/hpc.md
+++ b/jsoc/gsoc/hpc.md
@@ -39,9 +39,7 @@ Add a distributed training API for Flux models built on top of [Dagger.jl](https
 
 **Skills:** Familiarity with UCX, representing execution models as DAGs, Flux.jl, and data/model parallelism in machine learning
 
-**Mentors:** [Kyle Daruwalla](https://github.com/darsnack) and [Julian Samaroo](https://github.com/jpsamaroo)
-
-Mentors: [Valentin Churavy](https://github.com/vchuravy), [Tim Besard](https://github.com/maleadt), [Julian Samaroo](https://github.com/jpsamaroo)
+**Mentors:** [Kyle Daruwalla](https://github.com/darsnack), [Julian Samaroo](https://github.com/jpsamaroo), and [Brian Chen](https://github.com/ToucheSir)
 
 ## Sparse GPU and ML support
 

--- a/jsoc/gsoc/hpc.md
+++ b/jsoc/gsoc/hpc.md
@@ -33,7 +33,13 @@ Mentors: [Valentin Churavy](https://github.com/vchuravy), [Tim Besard](https://g
 
 ## Distributed Training
 
-Add a distributed training API to Flux, possibly inspired by PyTorch's equivalent. Any distributed training algorithm could be used (ideally the foundations make it easy to experiment with different setups), though the easiest is likely to implement an MXNet-like parameter server. It should demonstrate training a Flux model with data distributed over multiple nodes, with benchmarks.
+**Difficulty:** Hard
+
+Add a distributed training API for Flux models built on top of [Dagger.jl](https://github.com/JuliaParallel/Dagger.jl). More detailed milestones include building Dagger.jl abstractions for [UCX.jl](https://github.com/JuliaParallel/UCX.jl), then building tools to map Flux models into data parallel Dagger DAGs. The final result should demonstrate a Flux model training with multiple devices in parallel via the Dagger.jl APIs. A stretch goal will include mapping operations with a model to a DAG to facilitate model parallelism as well.
+
+**Skills:** Familiarity with UCX, representing execution models as DAGs, Flux.jl, and data/model parallelism in machine learning
+
+**Mentors:** [Kyle Daruwalla](https://github.com/darsnack) and [Julian Samaroo](https://github.com/jpsamaroo)
 
 Mentors: [Valentin Churavy](https://github.com/vchuravy), [Tim Besard](https://github.com/maleadt), [Julian Samaroo](https://github.com/jpsamaroo)
 


### PR DESCRIPTION
Updates distributed training GSoC project based on recent ML calls/Zulip threads and #1139. One concern I have is the location of this project on the webpage. Should it go under the ML section instead of HPC? I think a student looking to do a project along these lines will look in the ML section.

In conjunction with this, I wonder if the "Multi-GPU Training" project should be updated to reflect UCX instead of NCCL. Or maybe it can be scrapped since it has a lot of overlap with this project. It might make more sense to make that project more focused on the UCX development.

cc @jpsamaroo 

@ToucheSir do you want to co-mentor with Julian and me? I think we could use your wisdom 😉.