### PR TITLE
Fixes JuliaPro link

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -13,7 +13,7 @@ We provide several ways for you to run Julia:
 @@tight-list
 * In the terminal using the built-in Julia command line using the binaries provided below.
 * Using [Docker](https://docs.docker.com/) images from [Docker Hub](https://hub.docker.com/_/julia) maintained by the [Docker Community](https://github.com/docker-library/julia).
-* [JuliaPro](https://juliacomputing.com/products/juliapro.html) by [Julia Computing](https://juliacomputing.com/) includes Julia and the [Juno IDE](https://junolab.org/), along with access to a curated set of packages for plotting, optimization, machine learning, databases and much more (requires registration).
+* [JuliaPro](https://juliacomputing.com/products/juliapro/) by [Julia Computing](https://juliacomputing.com/) includes Julia and the [Juno IDE](https://junolab.org/), along with access to a curated set of packages for plotting, optimization, machine learning, databases and much more (requires registration).
 
 Please see [platform specific instructions](/downloads/platform/) for further installation instructions and if you have trouble installing Julia.
 If the provided download files do not work for you, please [file an issue in the Julia project](https://github.com/JuliaLang/julia/issues).


### PR DESCRIPTION
The current link on the website shows a 404, this PR fixes that.