### PR TITLE
GSoC: Link to documenter.md

### DIFF
--- a/jsoc/projects.md
+++ b/jsoc/projects.md
@@ -9,6 +9,7 @@ We have our project ideas organized roughly into the skill sets required:
 * [DeepChem.jl](/jsoc/gsoc/deepchem/) – Machine learning for atomic systems in Julia
 * [DFTK.jl](/jsoc/gsoc/dftk/) – Density-functional theory in Julia
 * [Differential Equations](/jsoc/gsoc/diffeq/) - Numerical methods for high-performance solving of differential equation models.
+* [Documentation tooling](/jsoc/gsoc/documenter/) - Tooling related to documentation generation, docstrings etc.
 * [Flux.jl](/jsoc/gsoc/flux/) - A flexible deep learning library.
 * [GeoStats.jl](/jsoc/gsoc/GeoStats/) - An extensible framework for high-performance geostatistics in Julia.
 * [High Performance and Parallel Computing](/jsoc/gsoc/hpc/) – write code that runs on lots of machines, goes really fast, processes lots of data, or all three.


### PR DESCRIPTION
It looks like a link to the new `documenter.md` page was missed in f05366c636639e7a35c6723846ede5a5c86d03d7.