### PR TITLE
Fix broken links to latest docs

### DIFF
--- a/blog/2017/01/moredots.md
+++ b/blog/2017/01/moredots.md
@@ -534,7 +534,7 @@ julia> s .= replace.(lowercase.(s), r"\s+", "-")
 ```
 
 Here, we take an array `s` of strings, we convert each string to
-lower case, and then we replace any sequence of whitespace (the [regular expression](https://docs.julialang.org/en/latest/manual/strings.html#Regular-Expressions-1)
+lower case, and then we replace any sequence of whitespace (the [regular expression](https://docs.julialang.org/en/v1/manual/strings/#Regular-Expressions)
 `r"\s+"`) with a hyphen `"-"`.  Since these two dot calls are nested,
 they are fused into a single loop over `s` and are written in-place in `s`
 thanks to the `s .= ...` (temporary *strings* are allocated in this process,

--- a/blog/2018/03/pifonts.md
+++ b/blog/2018/03/pifonts.md
@@ -16,7 +16,7 @@ But although Jones was one of the first, he wasn't influential enough to inspire
 
 (Original online [here](https://archive.org/details/euler-e059).)
 
-Julia embraces the Unicode standard [enthusiastically](https://docs.julialang.org/en/latest/manual/unicode-input/), so it's very easy to use the appropriate Greek (and other Unicode) letters in your code. In the REPL, for example, type `\pi TAB` to insert the Unicode character `U+03C0`:
+Julia embraces the Unicode standard [enthusiastically](https://docs.julialang.org/en/v1/manual/unicode-input/), so it's very easy to use the appropriate Greek (and other Unicode) letters in your code. In the REPL, for example, type `\pi TAB` to insert the Unicode character `U+03C0`:
 
 ```julia-repl
 julia> π

--- a/blog/2018/05/extensible-broadcast-fusion.md
+++ b/blog/2018/05/extensible-broadcast-fusion.md
@@ -224,13 +224,13 @@ operate directly upon the `Broadcasted` lazy wrapper instead of allocating the i
 array in an expression like `sum(X.^2 .+ Y.^2)`.
 
 
-[Broadcasting]: https://docs.julialang.org/en/latest/manual/arrays/#Broadcasting-1
+[Broadcasting]: https://docs.julialang.org/en/v1/manual/arrays/#Broadcasting
 
 ["fusing"]: /blog/2017/01/moredots
 
 [hacks]: https://github.com/MikeInnes/TakingBroadcastSeriously.jl
 
-[documented and available to packages]: https://docs.julialang.org/en/latest/manual/interfaces/#man-interfaces-broadcasting-1
+[documented and available to packages]: https://docs.julialang.org/en/v1/manual/interfaces/#man-interfaces-broadcasting
 
 [`BitArray`s]: https://docs.julialang.org/en/latest/base/arrays/#Base.BitArray
 

--- a/blog/2018/06/missing.md
+++ b/blog/2018/06/missing.md
@@ -231,7 +231,7 @@ Naturally, functions defined based on those listed above inherit their behavior.
 `findall(isequal(1), [1, missing, 2])` returns `[1]`, but `findall(==(1), [1, missing, 2])`
 throws an error when encountering a missing value.
 
-See the [manual](https://docs.julialang.org/en/latest/manual/missing/) for more details
+See the [manual](https://docs.julialang.org/en/v1/manual/missing/) for more details
 and illustrations about these rules. As noted above, they are generally consistent with
 those implemented by SQL's `NULL` and R's `NA`.
 

--- a/blog/2018/07/iterators-in-julia-0.7.md
+++ b/blog/2018/07/iterators-in-julia-0.7.md
@@ -107,7 +107,7 @@ Notice that our `EveryNth` struct is immutable and we never mutate the state inf
 
 As an aside, the `length` and `eltype` method definitions are not necessary.
 Instead, we could use the `IteratorSize` and `IteratorEltype` traits to say that we don't implement those functions and Julia's Base functions will not try to call them when iterating.
-[`collect`](https://docs.julialang.org/en/latest/base/collections/#Base.collect-Tuple{Any}) is notable for specializing on both of these traits to provide optimizations for different kinds of iterators.
+[`collect`](https://docs.julialang.org/en/v1/base/collections/#Base.collect-Tuple{Any}) is notable for specializing on both of these traits to provide optimizations for different kinds of iterators.
 
 ## Iteration in Julia 0.7
 
@@ -413,7 +413,7 @@ IterTools will definitely accept pull requests, and I'm interested in feedback o
 
 [^macroname]: This name is definitely up for debate!
 
-[^slurpsplat]: Slurping refers to  how using `args...` in a function definition "slurps" up the trailing arguments, and splatting is the inverse operation. The [Julia docs](https://docs.julialang.org/en/latest/manual/functions/#Varargs-Functions-1) say more on this.
+[^slurpsplat]: Slurping refers to  how using `args...` in a function definition "slurps" up the trailing arguments, and splatting is the inverse operation. The [Julia docs](https://docs.julialang.org/en/v1/manual/functions/#Varargs-Functions) say more on this.
 
 [^respell]: All other changes here are renaming or respelling something that appears in the original, for clarity's sake.
 

--- a/blog/2020/08/invalidations.md
+++ b/blog/2020/08/invalidations.md
@@ -442,5 +442,5 @@ One might hope that the next period of Julia's development might see significant
 [union-splitting]: https://julialang.org/blog/2018/08/union-splitting/
 [MethodAnalysis]: https://github.com/timholy/MethodAnalysis.jl
 [SnoopCompile]: https://github.com/timholy/SnoopCompile.jl
-[performance tips]: https://docs.julialang.org/en/latest/manual/performance-tips/
+[performance tips]: https://docs.julialang.org/en/v1/manual/performance-tips/
 [vscode]: https://www.julia-vscode.org/


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/www.julialang.org/issues/1268.

In the linked issue, Fredrik Ekre has a good point:

> I guess the links that have corresponding sections in the current manual can be updated, but I guess in general blogposts will always be outdated after some time.

So, that is why I have fixed the links only for blog posts published after 2017. That means that posts which are still actual like [invalidations](https://julialang.org/blog/2020/08/invalidations/) now have their link fixed. For older posts, I guess that the reader won't be surprised by broken links.

