### PR TITLE
Add a section on Slack Admins

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -15,6 +15,6 @@ The [Julia Community Standards](https://julialang.org/community/standards/) are 
 
 You can also contact the [Julia Stewards](https://julialang.org/community/stewards/) by emailing [stewards@julialang.org](mailto:stewards@julialang.org), in particular if your concern or conflict involves the admins and/or you would prefer a third party to resolve it.
 
-Slack lacks adequate moderations tools so at the present moment, you will have to ping one of the following moderators directly if you think the Julia Community Standards have been violated or otherwise need the support of an Admin. You can find a list of our current Admins here (Slack sign-in required): [https://julialang.slack.com/account/workspace-settings#admins](https://julialang.slack.com/account/workspace-settings#admins)
+Slack lacks adequate moderations tools so at the present moment, you will have to ping one of the following moderators directly if you think the Julia Community Standards have been violated or otherwise need the support of an Admin. See [the list of our current Slack Admins](https://julialang.slack.com/account/workspace-settings#admins) (Slack sign-in required)
 
 <!-- To create a new Slack Invite Link, see https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace Note that the link above expires every 30 days (or after 2,000 participants join with it) so we will need to generate a new one. (as of 2021, this seems to have changed...)-->

--- a/slack.md
+++ b/slack.md
@@ -1,6 +1,6 @@
 # The Julia Language Slack
 
-The Julia Language has an active Slack workspace/community with over 7,000 members. Slack is a space to have quick and informal correspondence with others in the community. We ask that if you have Julia usage questions you post them on [Discourse](https://discourse.julialang.org) so others can benefit from them or on Stack Overflow (but the Discourse community is much more welcoming in our opinion). 
+The Julia Language has an active Slack workspace/community with over 8,000 members. Slack is a space to have quick and informal correspondence with others in the community. We ask that if you have Julia usage questions, you post them on [Discourse](https://discourse.julialang.org) so others can benefit from them. You could also use Stack Overflow but the Discourse community is much more welcoming (in our opinion).
 
 ## You can find the link to join below:
 [Join us in the Julia Language Slack](https://join.slack.com/t/julialang/shared_invite/zt-nmal0i0x-LcYEtdnTameGsXmBzMzgog)
@@ -8,5 +8,26 @@ The Julia Language has an active Slack workspace/community with over 7,000 membe
 ### Issues using the link above? 
 [Send us a note so we can fix that!](mailto:logan@julialang.org)
 
+### Admins
+The [Julia Community Standards](https://julialang.org/community/standards/) are enforced on Slack by our Slack Admins. 
 
-<!-- To create a new Slack Invite Link, see https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace Note that the link above expires every 30 days (or after 2,000 participants join with it) so we will need to generate a new one. -->
+**If you see or experience any violation of those standards, or feel unsafe or upset, please contact us by sending a private message to one of the following folks listed below.** All communications will be treated confidentially but may be shared with other admins and/or the Julia Stewards.
+
+You can also contact the [Julia Stewards](https://julialang.org/community/stewards/) by emailing [stewards@julialang.org](mailto:stewards@julialang.org), in particular if your concern or conflict involves the admins and/or you would prefer a third party to resolve it.
+
+Slack lacks adequate moderations tools so at the present moment, you will have to ping one of the following moderators directly if you think the Julia Community Standards have been violated or otherwise need the support of an Admin. Our current Admins are:
+
+@@tight-list
+* Alex Arslan - @ararslan
+* Elliot Saba - @staticfloat
+* Jeff Bezanson - @jeffbezanson
+* Jon Malmaud - @malmaud
+* Keno Fischer - @keno
+* Logan Kilpatrick - @logankilpatrick
+* Matt Bauman - @mbauman
+* Stefan Karpinski - @stefan
+* Valentin Churavy - @vchuravy
+* Viral Shah - @viralbshah
+@@
+
+<!-- To create a new Slack Invite Link, see https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace Note that the link above expires every 30 days (or after 2,000 participants join with it) so we will need to generate a new one. (as of 2021, this seems to have changed...)-->

--- a/slack.md
+++ b/slack.md
@@ -15,19 +15,6 @@ The [Julia Community Standards](https://julialang.org/community/standards/) are 
 
 You can also contact the [Julia Stewards](https://julialang.org/community/stewards/) by emailing [stewards@julialang.org](mailto:stewards@julialang.org), in particular if your concern or conflict involves the admins and/or you would prefer a third party to resolve it.
 
-Slack lacks adequate moderations tools so at the present moment, you will have to ping one of the following moderators directly if you think the Julia Community Standards have been violated or otherwise need the support of an Admin. Our current Admins are:
-
-@@tight-list
-* Alex Arslan - @ararslan
-* Elliot Saba - @staticfloat
-* Jeff Bezanson - @jeffbezanson
-* Jon Malmaud - @malmaud
-* Keno Fischer - @keno
-* Logan Kilpatrick - @logankilpatrick
-* Matt Bauman - @mbauman
-* Stefan Karpinski - @stefan
-* Valentin Churavy - @vchuravy
-* Viral Shah - @viralbshah
-@@
+Slack lacks adequate moderations tools so at the present moment, you will have to ping one of the following moderators directly if you think the Julia Community Standards have been violated or otherwise need the support of an Admin. You can find a list of our current Admins here (Slack sign-in required): [https://julialang.slack.com/account/workspace-settings#admins](https://julialang.slack.com/account/workspace-settings#admins)
 
 <!-- To create a new Slack Invite Link, see https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace Note that the link above expires every 30 days (or after 2,000 participants join with it) so we will need to generate a new one. (as of 2021, this seems to have changed...)-->

--- a/slack.md
+++ b/slack.md
@@ -11,7 +11,7 @@ The Julia Language has an active Slack workspace/community with over 8,000 membe
 ### Admins
 The [Julia Community Standards](https://julialang.org/community/standards/) are enforced on Slack by our Slack Admins. 
 
-**If you see or experience any violation of those standards, or feel unsafe or upset, please contact us by sending an email to [slackadmins@julialang.org](mailto:slackadmins@julialang.org).** All communications will be treated confidentially but incidents may be shared the Julia Stewards.
+**If you see or experience any violation of those standards, or feel unsafe or upset, please contact us by sending an email to [slackadmins@julialang.org](mailto:slackadmins@julialang.org).** All communications will be treated confidentially but incidents may be shared the Julia Stewards (who will treat all information confidentially as well).
 
 You can also contact the [Julia Stewards](https://julialang.org/community/stewards/) by emailing [stewards@julialang.org](mailto:stewards@julialang.org), in particular if your concern or conflict involves the admins and/or you would prefer a third party to resolve it.
 

--- a/slack.md
+++ b/slack.md
@@ -11,10 +11,10 @@ The Julia Language has an active Slack workspace/community with over 8,000 membe
 ### Admins
 The [Julia Community Standards](https://julialang.org/community/standards/) are enforced on Slack by our Slack Admins. 
 
-**If you see or experience any violation of those standards, or feel unsafe or upset, please contact us by sending a private message to one of the following folks listed below.** All communications will be treated confidentially but may be shared with other admins and/or the Julia Stewards.
+**If you see or experience any violation of those standards, or feel unsafe or upset, please contact us by sending an email to [slackadmins@julialang.org](mailto:slackadmins@julialang.org).** All communications will be treated confidentially but incidents may be shared the Julia Stewards.
 
 You can also contact the [Julia Stewards](https://julialang.org/community/stewards/) by emailing [stewards@julialang.org](mailto:stewards@julialang.org), in particular if your concern or conflict involves the admins and/or you would prefer a third party to resolve it.
 
-Slack lacks adequate moderations tools so at the present moment, you will have to ping one of the following moderators directly if you think the Julia Community Standards have been violated or otherwise need the support of an Admin. See [the list of our current Slack Admins](https://julialang.slack.com/account/workspace-settings#admins) (Slack sign-in required)
+Slack lacks adequate moderations tools so at the present moment, you will have to [email the moderators](mailto:slackadmins@julialang.org) if you think the Julia Community Standards have been violated or otherwise need the support of an Admin. See [the list of our current Slack Admins](https://julialang.slack.com/account/workspace-settings#admins) (Slack sign-in required)
 
 <!-- To create a new Slack Invite Link, see https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace Note that the link above expires every 30 days (or after 2,000 participants join with it) so we will need to generate a new one. (as of 2021, this seems to have changed...)-->


### PR DESCRIPTION
We currently don't have it listed who are admins are so it is unclear who one should contact if we run into issues on Slack, adding in the folks who are in the Slack Admin Channel right now. 