### PR TITLE
Fix inconsistent footer regression in blog

### DIFF
--- a/blog/2020/09/rr-memory-magic.md
+++ b/blog/2020/09/rr-memory-magic.md
@@ -523,6 +523,3 @@ cosmic rays or gremlins living under the floor. Here, we were able to fairly con
 conclude that that the issue must indeed be bad memory. I like to say that `rr` turns a
 debugging problem into a data analysis problem and here, as is so often the case, the most
 insightful piece is figuring out what data is missing.
-
-
-{{about_the_author}}

--- a/blog/2021/04/gsod-2020-wrapup.md
+++ b/blog/2021/04/gsod-2020-wrapup.md
@@ -50,4 +50,3 @@ It is always worth acknowledging that without the hard work of our mentors, none
 
 Thank you to all of the technical writers and mentors mentioned above who made this GSoD a success. We are also happy to share that we have submitted our application for the GSoD 2021-2022 Season and are anticipating a decsion by mid-April. You can find our [proposal on the Julia Language Website under the JSoC Tab](https://julialang.org/jsoc/gsod/proposal/).
 
-{{about_the_author}}


### PR DESCRIPTION
It looks like in an effort to implement an "about the author" footer for this issue https://github.com/JuliaLang/www.julialang.org/issues/1009 in this PR https://github.com/JuliaLang/www.julialang.org/commit/89491455394ae340d46622cbbe89ae6c63b265c2, the introduced per-post footer messed with the site-wide footer.


There are the only affected pages, because these are the only ones using `{{about_the_author}}`
- https://julialang.org/blog/2021/04/gsod-2020-wrapup/
- https://julialang.org/blog/2020/09/rr-memory-magic/


Note: I barely know anything about CSS or documenter, so just decided to delete the footers until someone fixes it.


Faulty footer: 
![Screenshot from 2021-04-19 13-29-30](https://user-images.githubusercontent.com/17922991/115278410-696af580-a113-11eb-89fd-624344e8dae2.png)
Normal footer: 
![Screenshot from 2021-04-19 13-31-13](https://user-images.githubusercontent.com/17922991/115278525-8c95a500-a113-11eb-843f-6b16d4e9e929.png)