### PR TITLE
Fix Homebrew and macOS

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -132,7 +132,7 @@ Chocolatey automatically creates a shim for the Julia executable, so you simply 
 
 
 
-## HomeBrew on Mac
+## Homebrew on macOS
 
 Julia can be installed using the [Homebrew package manager](https://formulae.brew.sh/cask/julia) as follows:
 


### PR DESCRIPTION
AFAIK, the "brew" part of Homebrew is not title-cased (https://brew.sh/) and the brand name of macOS is not "Mac".