### PR TITLE
Set upcoming release to 1.7.0-beta2

### DIFF
--- a/config.md
+++ b/config.md
@@ -23,8 +23,7 @@
 <!--
 If the following lines are commented, the "upcoming release" section
 in `downloads/index.md` will not be shown.
-
-@def upcoming_release = "1.6.0-rc3"
-@def upcoming_release_short = "1.6"
-@def upcoming_release_date = "March 16, 2021"
 -->
+@def upcoming_release = "1.7.0-beta2"
+@def upcoming_release_short = "1.7"
+@def upcoming_release_date = "June 21, 2021"

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -185,9 +185,9 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
       <th> Generic Linux on x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3">
         <a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz">64-bit (glibc)</a>
-        (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz.asc">GPG</a>),
+        (<a href="https://julialang-s3.julialang.org/bin/linux/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-x86_64.tar.gz.asc">GPG</a>)<!--,
         <a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz">64-bit (musl)</a><sup>[<a href=#musl-fn>1</a>]</sup>
-        (<a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz.asc">GPG</a>)
+        (<a href="https://julialang-s3.julialang.org/bin/musl/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-musl-x86_64.tar.gz.asc">GPG</a>)-->
       </td>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-i686.tar.gz">32-bit</a>
         (<a href="https://julialang-s3.julialang.org/bin/linux/x86/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-i686.tar.gz.asc">GPG</a>)


### PR DESCRIPTION
Also comment out the musl download link for 1.7.0-beta2, since the musl build seems to have regressed.