### PR TITLE
Add "Be Open" section to CoC

### DIFF
--- a/community/standards.md
+++ b/community/standards.md
@@ -18,6 +18,10 @@ If you believe one of these standards has been violated, you can either file an 
 
 Constructive criticism and suggestions are welcome, but high-traffic forums do not generally have the bandwidth for extensive discourse. Consider writing a blog post if you feel that you have enough to say on a particular subject.
 
+### Be open
+
+As a project and community build on the principles of open source, we ask everyone to be open. Where possible, we ask that you use public forums for conversation, discussion, and when asking for help. Open discussions allow: future users to benefit from the question/discussion, potentially incorrect or incomplete answers to be more swiftly corrected, and more people to see and engage in the initial conversation. More concretely, ask for help on forums with high visibility and have design discussions in places where future contributors or users can read about why/how a decision was made.
+
 ### For Researchers
 
 We welcome the participation of researchers of all kinds in the Julia community. However, please remember that open source development is a social process and that the participants on the other side of any interaction are (obviously) humans. If you are doing research *on the community or its processes*, you are likely performing Human Subjects Research (HSR) and are expected to abide by the highest standards of ethics and professional practice. Meeting this expectation is your responsibility. In particular, please be aware that Institutional Review Boards (IRBs) or other review committees may not have sufficient context or experience to understand the social processes of an open source community. We consider engaging in unethical research (human subject or otherwise) to be a cause for bans or other sanctions from the community.


### PR DESCRIPTION
Inspired by: https://numpy.org/code-of-conduct/ and based on the conversation here: https://github.com/JuliaLang/www.julialang.org/issues/1235 

I think codifying this in the DNA of the community will help the sustainability of the ecosystem and language. CC: @JuliaLang/stewards Should we ask for public comments on this like @Keno did on the Researchers section? 