### PR TITLE
Fix GitHub linguist's calculation to better reflect source of website

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
Hi!

Currently linguist displays a major chunk of the website source to be jupyter notebooks (which seems incorrect, seeing that only 3 such ipynb files exist). 

This is just me being pedantic but it would be more appropriate to have the source language of the website (HTML/CSS/JS) to be reflected in linguist's calculation instead of jupyter notebooks.

This PR aims to fix this issue.