### PR TITLE
Generally fix lists, nested lists + make @@tight-list unnecessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,9 @@ blc https://julialang.org -ro
 ```
 
 (it takes a while, and may require you to do it in several steps).
+
+## FAQ
+
+### tight lists
+
+This is mostly a legacy item. If lists look wrong on the page, please open an issue. You should not have to use `@@tight-list ... @@` anymore.

--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ blc https://julialang.org -ro
 ### tight lists
 
 This is mostly a legacy item. If lists look wrong on the page, please open an issue. You should not have to use `@@tight-list ... @@` anymore.
+
+If you want nested lists, make sure the indentation for the nested list is made with _spaces_ and not with tabs.

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -14,9 +14,14 @@
 
   {{isdef title}} <title>{{fill title}}</title>   {{end}}
 
-  {{ispage /blog/* /jsoc/gsoc/*}}
+  {{ispage /blog/* /jsoc/gsoc/* /contribute/* /downloads/* /community/*}}
   <style>
 	  .container ul li p {margin-bottom: 0;}
+		.container ol li p {margin-bottom: 0;}
+		.container ul ul {margin: .4em 0 .4em 0;}
+		.container ul ol {margin: .4em 0 .4em 0;}
+		.container ol ul {margin: .4em 0 .4em 0;}
+		.container ol ol {margin: .4em 0 .4em 0;}
   </style>
   {{end}}
 

--- a/blog/2016/03/arrays-iteration.md
+++ b/blog/2016/03/arrays-iteration.md
@@ -44,12 +44,10 @@ diverse collection of concrete arrays in mind.
 
 In core julia, some types we support fairly well are:
 
-@@tight-list
 - `Array`: the prototype for all arrays
 - `Range`s: a good example of what I often consider a "computed" array, where essentially none of the values are stored in memory. Since there is no storage, these are immutable containers: you can't set values in individual slots.
 - `BitArray`s: arrays that can only store 0 or 1 (`false` or `true`), and for which the internal storage is packed so that each entry requires only one bit.
 - `SubArray`s: the problems this type introduced, and the resolution we adopted, probably serves as the best model for the generalizations considered here. Therefore, this case is discussed in greater detail below.
-@@
 
 Another important class of array types in Base are sparse arrays:
 `SparseMatrixCSC` and `SparseVector`, as well as other sparse
@@ -71,11 +69,9 @@ operations.
 Outside of Base, there are some other mind-stretching examples of
 arrays, including:
 
-@@tight-list
 - `DataFrames`: indexing arrays with symbols rather than integers. Other related types include `NamedArrays`, `AxisArrays`.
 - `Interpolations`: indexing arrays with non-integer floating-point numbers
 - `DistributedArrays`: another great example of a case in which you need to think through access patterns carefully
-@@
 
 ## SubArrays: a case study
 
@@ -117,10 +113,8 @@ types useful in generic programming.
 
 It's also worth pointing out some problems:
 
-@@tight-list
 - Most importantly, it requires that one adopt a slightly different programming style. Despite being well into another release cycle, this transition is still [not complete, even in Base](https://github.com/JuliaLang/julia/pull/15434#issuecomment-194991739).
 - For algorithms that involve two or more arrays, there's a possibility that their "best" iterators will be of different types. *In principle*, this is a big problem. Consider matrix-vector multiplication, `A[i,j]*v[j]`, where `j` needs to be in-sync for both `A` and `v`, yet you'd also like all of these accesses to be maximally-efficient.  *In practice*, right now this isn't a burning problem: even if our arrays don't all have efficient linear indexing, to my knowledge all of our (dense) array types have efficient cartesian indexing. Since indexing by `N` integers (where `N` is equal to the dimensionality of the array) is always performant, this serves as a reliable default for generic code. (It's worth noting that this isn't true for sparse arrays, and the lack of a corresponding generic solution is probably the main reason we lack a generic API for writing sparse algorithms.)
-@@
 
 Unfortunately, I suspect that if we want to add support for certain
 new operations or types (specific examples below), it will force us to
@@ -358,12 +352,10 @@ stored in `dest[1]`.
 
 These examples suggest a formalization of `AbstractArray`:
 
-@@tight-list
 - `AbstractArray`s are specialized associative containers, in that the allowable "keys" may be restricted by more than just their julia type.  Specifically, the allowable keys must be representable as a cartesian product of one-dimensional lists of values.  The allowed keys may depend not just on the array type but also the specific array (e.g., its size).  Attempted access by keys that cannot be converted to one of the allowed keys, for that specific array, result in `BoundsError`s.
 - For any given array, one must be able to generate a finite-dimensional parametrization of the full domain of valid keys from the array itself.  This might only require knowledge of the array size, or the keys might depend on some internal storage (think `DataFrames` and `OffsetArrays`).  In some cases, just the array type might be sufficient (e.g., `FixedSizeArrays`).  By this definition, note that a `Dict{ASCII5,Int}`, where `ASCII5` is a type that means an ASCII string with 5 characters, would qualify as a 5-dimensional (sparse) array, but that a `Dict{ASCIIString,Int}` would not (because there is no length limit to an `ASCIIString`, and hence no finite dimensionality).
 - An array may be indexed by more than one key type (i.e., keys may have multiple parametrizations).  Different key parametrizations are equivalent when they refer to the same element of a given array. Linear indexes and cartesian indexes are simple examples of interconvertable representations, but specialized iterators can produce other key types as well.
 - Arrays may support multiple iterators that produce non-equivalent key sequences.  In other words, a row-major matrix may support both `CartesianRange` and `RowMajorRange` iterators that access elements in different orders.
-@@
 
 # Finding a way forward
 

--- a/blog/2021/04/gsod-2020-wrapup.md
+++ b/blog/2021/04/gsod-2020-wrapup.md
@@ -11,42 +11,43 @@ meta = [
     ("name", "twitter:creator:id", "284333988"),
     ("name", "twitter:card", "summary_large_image")
     ]
+rss_pubdate = Date(2021, 4, 04)
 +++
-
-@def rss_pubdate = Date(2021, 4, 04)
 
 ![82606204-8c8bce80-9b6b-11ea-9847-6a4b28a0761d](https://user-images.githubusercontent.com/35577566/113520086-96c97800-9545-11eb-9599-ee0528acc48b.png)
 
 We at the Julia Language, are grateful to have participated in Google Season of Docs [for the first time during the 2020 - 2021 season](https://discourse.julialang.org/t/the-julia-language-google-season-of-docs-2020/39279). During this period, we had [3 writers successfully complete their projects through GSoD](https://developers.google.com/season-of-docs/docs/2020/participants) and one writer successfully complete their project through Julia Season of Docs (a counterpart to GSoD with the only difference being we pay the writer directly rather than have them funded by Google).
 
-We are proud to share the following projects that were successfully completed: 
+We are proud to share the following projects that were successfully completed:
 
-## [Elizaveta Semenova](https://github.com/elizavetasemenova): Gaussian Processes in Julia and Turing
+## Projects
+
+### [Elizaveta Semenova](https://github.com/elizavetasemenova): Gaussian Processes in Julia and Turing
 
 - Initial Proposal: [https://developers.google.com/season-of-docs/docs/2020/participants/project-julialang-liza](https://developers.google.com/season-of-docs/docs/2020/participants/project-julialang-liza)
 - Final writeup: [https://github.com/elizavetasemenova/gp_turing](https://github.com/elizavetasemenova/gp_turing)
 
-## [Maja Gwóźdź](https://github.com/mkg33): The unified documentation of Scientific Machine Learning
+### [Maja Gwóźdź](https://github.com/mkg33): The unified documentation of Scientific Machine Learning
 
 - Initial Proposal: [https://developers.google.com/season-of-docs/docs/2020/participants/project-julialang-mkg33](https://developers.google.com/season-of-docs/docs/2020/participants/project-julialang-mkg33)
 - Final writeup: [https://drive.google.com/file/d/1HHW-cSVOl1oUfqu4jTXZnTg8Z0LjuDd7/view](https://drive.google.com/file/d/1HHW-cSVOl1oUfqu4jTXZnTg8Z0LjuDd7/view)
 
-## [Liliana Badillo](https://github.com/lilianabs): Reinventing the FluxML Website
+### [Liliana Badillo](https://github.com/lilianabs): Reinventing the FluxML Website
 
 - Initial Proposal: [https://developers.google.com/season-of-docs/docs/2020/participants/project-julialang-sophb](https://developers.google.com/season-of-docs/docs/2020/participants/project-julialang-sophb)
 - Final writeup: [https://docs.google.com/document/d/1qbadTHNhTZN1WJY9uVY4iGIOI7ciFixk1mMcNYZcpNM/edit#](https://docs.google.com/document/d/1qbadTHNhTZN1WJY9uVY4iGIOI7ciFixk1mMcNYZcpNM/edit#)
 
-## [Luca Ferranti](https://github.com/lucaferranti): Developing JuliaIntervals documentation
+### [Luca Ferranti](https://github.com/lucaferranti): Developing JuliaIntervals documentation
 
 - Initial Proposal: [https://discourse.julialang.org/t/the-julia-language-x-gsod-x-jsod-2020/45216](https://discourse.julialang.org/t/the-julia-language-x-gsod-x-jsod-2020/45216)
 - Final writeup: [https://lucaferranti.github.io/posts/2021/03/jsod/](https://lucaferranti.github.io/posts/2021/03/jsod/)
 
 
-### Our Mentors
+## Our Mentors
 
 It is always worth acknowledging that without the hard work of our mentors, none of the programs we run and participate in would be possible. Thank you to Cameron Pfiffer, Hong Ge, Martin Trapp, Chris Rackauckas, Dhairya Gandhi, David P Sanders, and the rest of the Julia community who supported these writers.
 
-### Closing Thoughts
+## Closing Thoughts
 
 Thank you to all of the technical writers and mentors mentioned above who made this GSoD a success. We are also happy to share that we have submitted our application for the GSoD 2021-2022 Season and are anticipating a decsion by mid-April. You can find our [proposal on the Julia Language Website under the JSoC Tab](https://julialang.org/jsoc/gsod/proposal/).
 

--- a/community/discourse.md
+++ b/community/discourse.md
@@ -2,13 +2,11 @@
 
 The primary online discussion venue for Julia is the [Discourse forum](https://discourse.julialang.org/). Discourse is the right place to do any of the following:
 
-@@tight-list
 * **Keep up to date** on important Julia announcements like language releases and JuliaCon.
 * **Ask a question** about any aspect of using or developing Julia or its associated packages and tools. The Discourse forum is the best place to get a fast, high-quality answer to your Julia question. There are subcategories for various Julia application domains such as machine learning, finance, visualisation and GPUs. Questions from newcomers are always welcome: you can use the “first steps” tag to highlight your question as one that would benefit other new users.
 * **Respond to others’ questions**: our community thrives when people share their knowledge and experience.
 * **Announce a new package** or solicit feedback about something you have been developing.
 * **Advertise** Julia-related jobs and community events.
-@@
 
 For Chinese users a Simplified Chinese version discourse is also hosted by the community. Please click this [Julia中文论坛](https://discourse.juliacn.com/) link.
 

--- a/community/localization.md
+++ b/community/localization.md
@@ -2,13 +2,12 @@
 
 Julia’s official documentation is in English, but many groups work to translate and localize documentation and other resources. The following is a list of past localization efforts that may not be active anymore.
 
-@@tight-list
 * [JuliaTokyo](http://julia.tokyo/) (Japanese)
 * [JuliaLangEs](https://github.com/JuliaLangEs) (Spanish)
 * [JuliaLangPt](https://github.com/JuliaLangPt) (Portuguese)
 * [JuliaKorea](https://juliakorea.github.io/ko/) (Korean)
 * [JuliaGerman](https://github.com/JuliaLangGerman) (German)
 * [Julia Francophonie](https://www.juliafran.org/) (French)
-@@
+
 
 Please [let us know](https://github.com/JuliaLang/www.julialang.org/issues/new) if you have another organization dedicated to these efforts.

--- a/community/organizations.md
+++ b/community/organizations.md
@@ -6,18 +6,15 @@ The following is a non-comprehensive list of Julia GitHub Organizations, grouped
 
 ### Julia
 
-@@tight-list
 * [JuliaLang](https://github.com/JuliaLang) – A fresh approach to numerical computing
 * [JuliaRegistries](https://github.com/JuliaRegistries)
 * [JuliaCon](https://github.com/JuliaCon) – The Julia Conference
 * [JuliaAcademy](https://github.com/JuliaAcademy) – The definitive source for learning all things Julia.
 * [JuliaCommunity](https://github.com/JuliaCommunity) – Organizing Julia Community Initiatives
 * [Julia Lab](https://github.com/JuliaLabs) - Julia Lab at MIT CSAIL
-@@
 
 ### General
 
-@@tight-list
 * [Holy Lab](https://github.com/HolyLab)
 * [Julia-i18n](https://github.com/Julia-i18n) – Internationalization (i18n) and localization (L10n) for Julians ([Twitter](https://twitter.com/julia_i18n), [Gitter](https://gitter.im/Julia-i18n/julia-i18n))
 * [JuliaAudio](https://github.com/JuliaAudio)
@@ -35,11 +32,9 @@ The following is a non-comprehensive list of Julia GitHub Organizations, grouped
 * [JuliaTime](https://github.com/JuliaTime) – Date and time libraries
 * [Julia Visual Studio Code](https://github.com/julia-vscode) - The Julia extension for Visual Studio Code provides rich support for the Julia programming language
 * [JunoLab](https://github.com/JunoLab) – The Juno IDE for Atom
-@@
 
 ### Computing
 
-@@tight-list
 * [JuliaActors](https://github.com/JuliaActors) – Concurrent Programming with the Actor Model
 * [JuliaArrays](https://github.com/JuliaArrays) – Custom array types (and utilities for building array types)
 * [JuliaBerry](https://github.com/JuliaBerry) – [Julia resources for the Raspberry Pi](https://juliaberry.github.io/)
@@ -52,11 +47,9 @@ The following is a non-comprehensive list of Julia GitHub Organizations, grouped
 * [JuliaPerf](https://github.com/JuliaPerf) - Performance tools
 * [JuliaSIMD](https://github.com/JuliaSIMD) - SIMD vectorization in Julia
 * [JuliaWeb](https://github.com/JuliaWeb) – Web stack
-@@
 
 ### Mathematics
 
-@@tight-list
 * [AlgebraicJulia](https://github.com/AlgebraicJulia) – Applied Category Theory
 * [JuliaDiff](https://github.com/JuliaDiff/) – [Differentiation tools](https://www.juliadiff.org/)
 * [JuliaGeometry](https://github.com/JuliaGeometry) – Computational Geometry
@@ -71,11 +64,9 @@ The following is a non-comprehensive list of Julia GitHub Organizations, grouped
 * [JuliaSparse](https://github.com/JuliaSparse) – Sparse matrix solvers
 * [JuMP-dev (formerly JuliaOpt)](http://jump.dev) – JuMP is a modeling language and supporting packages for mathematical optimization in Julia
 * [SciML (formerly JuliaDiffEq)](https://github.com/SciML) – [Open source software for scientific machine learning](https://sciml.ai) ([Gitter](https://gitter.im/JuliaDiffEq/Lobby))
-@@
 
 ### Scientific Domains
 
-@@tight-list
 * [BioJulia](https://github.com/BioJulia) – [Biology, bioinformatics, computational biology](https://biojulia.net) ([Gitter](https://gitter.im/BioJulia/home))
 * [Climate Modeling Alliance (CliMA)](https://github.com/CliMA) - An alliance of scientists, engineers and applied mathematicians, dedicated to pioneering a new, data-informed approach to climate modelingf
 * [EcoJulia](https://github.com/EcoJulia) – Ecology
@@ -97,31 +88,25 @@ The following is a non-comprehensive list of Julia GitHub Organizations, grouped
 * [JuliaRobotics](https://github.com/JuliaRobotics)
 * [JuliaTelecom](https://github.com/JuliaTelecom) [[🌐–page]](https://github.com/JuliaTelecom/SiteMap) – Telecommunications
 * [ModiaSim](https://github.com/ModiaSim) – Physical systems modelling/simulation with differential & algebraic equations
-@@
 
 ### Astronomy/Space
 
-@@tight-list
 * [JuliaAstro](https://github.com/JuliaAstro) [[🌐–page]](https://juliaastro.github.io/) – Astronomy
 * [JuliaAstrodynamics](https://github.com/JuliaAstrodynamics)
 * [juliahci](https://github.com/juliahci) – High-contrast imaging
 * [JuliaSpace](https://github.com/JuliaSpace)
-@@
 
 ### Physics/Quantum mechanics
 
-@@tight-list
 * [JuliaAtoms](https://github.com/JuliaAtoms)
 * [JuliaPhysics](https://github.com/JuliaPhysics) – Physics
 * [JuliaWaveScattering](https://github.com/JuliaWaveScattering) – Linear wave equations (acoustic, elastic, electromagnetic, quantum)
 * [JuliaQuantum](https://github.com/JuliaQuantum) – Quantum science and technology
 * [qojulia](https://github.com/qojulia) – QuantumOptics.jl related projects
 * [QuantumBFS](https://github.com/QuantumBFS)
-@@
 
 ### Data Science
 
-@@tight-list
 * [FluxML](https://github.com/FluxML) - Machine Learning and Differentiable Programming Framework
 * [JuliaAI](https://github.com/JuliaAI) - Home for repositories in the MLJ (Machine Learning in Julia) project
 * [JuliaData](https://github.com/JuliaData) – Data manipulation, storage, and I/O in Julia
@@ -132,21 +117,18 @@ The following is a non-comprehensive list of Julia GitHub Organizations, grouped
 * [JuliaText](https://github.com/JuliaText) – Natural Language Processing (NLP), Computational Linguistics and (textual) Information Retrieval
 * [queryverse](https://github.com/queryverse) – Julia Packages for Data Science
 * [TuringLang](https://github.com/TuringLang) – Bayesian inference with probabilistic programming
-@@
 
 ### Visualizations
 
-@@tight-list
 * [GiovineItalia](https://github.com/GiovineItalia) – Plotting (with [Gadfly](https://github.com/GiovineItalia/Gadfly.jl))
 * [JuliaGizmos](https://github.com/JuliaGizmos)
 * [JuliaGL](https://github.com/JuliaGL) – OpenGL API and ecosystem ([Gitter](https://gitter.im/JuliaGL/meta))
 * [JuliaGraphics](https://github.com/JuliaGraphics) – Drawing, Colors, GUIs
 * [JuliaPlots](https://github.com/JuliaPlots) – [Data visualization](https://juliaplots.github.io/)
-@@
 
 
 ### Misc.
-@@tight-list
+
 * [JuliaCN](https://github.com/JuliaCN)
 * [JuliaGaming](https://github.com/JuliaGaming) – Open source games built in the Julia Programming Language.
 * [JuliaKorea](https://github.com/juliakorea) - Julia Korea organization
@@ -156,7 +138,6 @@ The following is a non-comprehensive list of Julia GitHub Organizations, grouped
 * [JuliaTokyo](https://github.com/JuliaTokyo) - Yet another Julialang community.
 * [Julia-Streamers](https://github.com/Julia-Streamers) – The official organization for the Julia Streaming community!
 * [QuantEcon](https://github.com/QuantEcon)
-@@
 
 
 If you know of a Julia GitHub org not shown here, please open a Pull Request so we can keep this up to date.

--- a/community/otherchannels.md
+++ b/community/otherchannels.md
@@ -4,9 +4,7 @@ We also have an unofficial [Gitter](https://gitter.im/JuliaLang/julia) channel. 
 
 The Julia Language is also present and active on the following platforms in order to engage the widest audience possible:
 
-@@tight-list
 * **[LinkedIn](https://www.linkedin.com/company/the-julia-language/)**
 * **[Facebook](https://www.facebook.com/TheJuliaLanguage/)**
 * **[Pinterest](https://www.pinterest.com/JuliaLanguage/)**
 * **[Instagram](https://www.instagram.com/Julia.language/)**
-@@

--- a/community/stewards.md
+++ b/community/stewards.md
@@ -8,7 +8,6 @@ The spirit of community is crucial to free/open-source development. In the large
 
 All members of the Julia community are expected to abide by the community standards and encourage others to do so. To ensure that some group has the obligation and authority to cope with conflicts, a group known as the “Julia Stewards” has been created. The current membership of this group is:
 
-@@tight-list
 * Milan Bouchet-Valat
 * Simon Byrne
 * Tim Holy
@@ -16,7 +15,6 @@ All members of the Julia community are expected to abide by the community standa
 * Steven G. Johnson
 * Stefan Karpinski
 * Viral Shah
-@@
 
 As needed, this group can be contacted at [stewards@julialang.org](mailto:stewards@julialang.org). Other than the committee listed above, there are no other recipients of emails sent to this address, and **all communications shall be treated confidentially**.
 
@@ -24,7 +22,6 @@ As needed, this group can be contacted at [stewards@julialang.org](mailto:stewar
 
 **No one shall be retaliated against for good-faith participation in a complaint**. In general, violations of the community standards will generate one or more of the following responses from the Stewards:
 
-@@tight-list
 1. Informal feedback, privately and/or (for public violations) in the forum where a violation appeared, with the goal of encouraging good-faith contributions and mutual understanding while making offenders aware of the problem and preventing future incidents. Where possible, good intentions of the participants should be assumed.
 2. Gross online violations of community standards may result in immediate deletion of the offending comments, coupled with informal feedback.
 3. For severe cases, especially persistent, disruptive violations despite repeated warnings and other feedback, a formal investigation may be convened by the stewards.
@@ -32,7 +29,6 @@ As needed, this group can be contacted at [stewards@julialang.org](mailto:stewar
     * The investigation shall be as confidential as possible, and this expectation shall be communicated to all participants. Identities and testimonies of participants shall, where possible, be known only to the committee.
     * The committee shall provide a private written report detailing its findings and recommendations to the stewards, complainant, and respondent. If a violation has been found, recommendations may include bans and other alterations of online privileges, or in less severe cases may request apologies and other informal resolutions.
     * The conclusions of the investigative committee are final and cannot be appealed except in cases of gross misconduct or major factual errors.
-@@
 
 ## Bans
 
@@ -40,17 +36,15 @@ The public Julia forums (e.g. [Discourse](https://discourse.julialang.org/)) and
 
 Note that:
 
-@@tight-list
 * Long-term bans shall only be undertaken in response to the recommendations of a formal investigation by the Julia stewards as described above. (A temporary ban may be imposed by Julia admins in response to an urgent situation, but shall be followed by a formal investigation if the ban is to continue.)
 * After a predetermined period, not to exceed six months, the banned individual may request that the ban be lifted, by acknowledging his/her past violations and providing a written plan to avoid such violations in the future. This request will typically be considered by the same committee that recommended the initial ban.
-@@
 
 ## Becoming a Steward
 
-The Julia Stewards were originally chosen for their long term commitment and quality contributions to the Julia community. Stewards currently serve at will and do not have a pre-defined appointment term. If a steward decides to give up their role and move on, the other stewards may seek out an individual whom they know has been a long term contributor to the Julia community. This is a high trust role given the implications mentioned above, which is generally why there is a need for folks to be trusted in the community before they become a steward. 
+The Julia Stewards were originally chosen for their long term commitment and quality contributions to the Julia community. Stewards currently serve at will and do not have a pre-defined appointment term. If a steward decides to give up their role and move on, the other stewards may seek out an individual whom they know has been a long term contributor to the Julia community. This is a high trust role given the implications mentioned above, which is generally why there is a need for folks to be trusted in the community before they become a steward.
 
 In addition to the stewards seeking out folks to add to the committee, you can also nominate someone (including yourself) to join the committee, even if there is not a vacancy. Nominations are accepted on a rolling basis and will be reviewed if/when the current stewards determine they need to bring on additional support. Nominations are reviewed on the axis of long term commitment and contributions to the Julia community (which need not be technical in nature). 
 
 The nomination form can be found here: [Julia Steward Nomination Form](https://forms.gle/7R8X7dpDh4DpWsJ1A)
 
-Please contact the stewards: [stewards@julialang.org](mailto:stewards@julialang.org) if you have questions about this process. 
+Please contact the stewards: [stewards@julialang.org](mailto:stewards@julialang.org) if you have questions about this process.

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -2,70 +2,55 @@
 
 ## Welcome!
 The purpose of this document is to help YOU contribute to the Julia Ecosystem. You don't need to be a seasoned developer to help Julia grow and improve.  
-Anyone willing to contribute will find here a roadmap from zero to hero (or from a hundred to one thousand, if you are a pro contributor already). Both code and non-code contributions are welcome, no matter your level of experience or background. This document aims to help you find out: 
+Anyone willing to contribute will find here a roadmap from zero to hero (or from a hundred to one thousand, if you are a pro contributor already). Both code and non-code contributions are welcome, no matter your level of experience or background. This document aims to help you find out:
 
-@@tight-list
--   how you can contribute to match your skills and interests
--   what tools and resources can help you contribute confidently
--   where you can find ideas for fixes to propose in your first contribution
-@@
+- how you can contribute to match your skills and interests
+- what tools and resources can help you contribute confidently
+- where you can find ideas for fixes to propose in your first contribution
 
 ## Why contribute?
 There is a spectrum of benefits to contributing - some more obvious than others. Open source projects rely on contributions from volunteers, enabling them to grow and develop. You will be making a difference to one of the most quickly growing languages, and the future of open-source software as a whole. Benefits of contributing:  
 
-@@tight-list
--   engage with the community
--   build a track record of public contributions (e.g.. GitHub) which will help your career
--   build confidence with the language and the libraries
--   gain exposure for your library
-@@
+- engage with the community
+- build a track record of public contributions (e.g.. GitHub) which will help your career
+- build confidence with the language and the libraries
+- gain exposure for your library
 
 Types of contributions vary depending on your experience, background, and the nature of your interest in Julia. Types of contributions  
 
-@@tight-list
--   improving documentation
--   sharing your (new) package
--   review a package submitted to the Julia Registry
--   file a bug report
--   write tests
--   contributing to core Julia
--   contributing to other libraries
-@@
+- improving documentation
+- sharing your (new) package
+- review a package submitted to the Julia Registry
+- file a bug report
+- write tests
+- contributing to core Julia
+- contributing to other libraries
 
 and more.
 
 ## Chose your path
-Your next step is to identify which kind of contributor you are. There are multiple paths, some of which cross. Here is a high level overlview of how you might want to contribut. The question is: do you want to ... 
+Your next step is to identify which kind of contributor you are.
+There are multiple paths, some of which cross. Here is a high level overview of how you might want to contribute.
+The question is: do you want to ...
 
-@@tight-list
--   Discover
--   Connect
-	@@tight-list
-	-   read code of conduct
-	-   ask questions on Slack or Discourse
-	-   engage on Twitter
-	@@
--   Learn
--   Build
-	@@tight-list
-	-   write a blogpost
-	-   cite Julia
-	-   report a bug
-	-   make feature request
-	-   make pull request
-	-   review documentation
-	-   share a use case
-	-   develop and submit a library
-	-   include future pans for your library
-	@@
--   Help
-	@@tight-list
-	-   spread a word about Julia's Ecosystem
-	-   submit a use case
-	-   answer questions on Slack and Discourse
-	-   contribute something that isn't addressed in this guide!
-	@@
-@@
-
-
-
+- Discover
+- Connect
+  - read the code of conduct
+  - ask questions on Slack or Discourse
+  - engage on Twitter
+- Learn
+- Build
+  - write a blogpost
+  - cite Julia
+  - report a bug
+  - make feature request
+  - make pull request
+  - review documentation
+  - share a use case
+  - develop and submit a library
+  - include future pans for your library
+- Help
+	- spread a word about Julia's Ecosystem
+	- submit a use case
+	- answer questions on Slack and Discourse
+	- contribute something that isn't addressed in this guide!

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -50,7 +50,7 @@ The question is: do you want to ...
   - develop and submit a library
   - include future pans for your library
 - Help
-	- spread a word about Julia's Ecosystem
-	- submit a use case
-	- answer questions on Slack and Discourse
-	- contribute something that isn't addressed in this guide!
+  - spread a word about Julia's Ecosystem
+  - submit a use case
+  - answer questions on Slack and Discourse
+  - contribute something that isn't addressed in this guide!

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -1,5 +1,3 @@
-
-
 # Download Julia
 
 If you like Julia, please consider starring us [on GitHub](https://github.com/JuliaLang/julia) and spreading the word!
@@ -10,14 +8,12 @@ If you like Julia, please consider starring us [on GitHub](https://github.com/Ju
 
 We provide several ways for you to run Julia:
 
-@@tight-list
 * In the terminal using the built-in Julia command line using the binaries provided below.
 * Using [Docker](https://docs.docker.com/) images from [Docker Hub](https://hub.docker.com/_/julia) maintained by the [Docker Community](https://github.com/docker-library/julia).
 
 Please see [platform specific instructions](/downloads/platform/) for further installation instructions and if you have trouble installing Julia.
 If the provided download files do not work for you, please [file an issue in the Julia project](https://github.com/JuliaLang/julia/issues).
 Different OSes and architectures have varying [tiers of support](/downloads/#currently_supported_platforms), and are listed at the bottom of this page.
-@@
 
 ---
 
@@ -102,6 +98,7 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
 ~~~
 
 Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.sha256) formats.
+
 
 @@row @@col-12
 ~~~

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -15,42 +15,35 @@ Julia is available for Windows 7 and later for both 32 bit and 64 bit versions.
 
 
 ### Installation Notes
-@@tight-list
+
 1.  Download the Windows Julia installer from https://julialang.org/downloads/. Note, the 32-bit Julia binaries work on both 32-bit and 64-bit Windows  (x86 and x86\_64), but the 64-bit Julia binaries only run on 64-bit Windows (x86\_64).
 2. Run the installer and note the installation directory. The installation directory should look something like \winpath, *please note this path*.
-@@
 
 To invoke Julia by simply typing `julia` in the command line, the Julia executable directory needs to be added to PATH. Perform the following steps to add Julia to PATH.
 
 
 #### Adding Julia to PATH on Windows 10,
 
-@@tight-list
 1.  Open Run (Windows Key + R),  type in `rundll32 sysdm.cpl,EditEnvironmentVariables` and hit enter.
 2.  Under either the "User Variables" or "System Variables" section, find the row with "Path", and click edit.
 3.  The "Edit environment variable" UI will appear. Here, click "New", and paste in the directory noted from the installation stage. This should look something like \winpathbin.
 4.  Click OK. You can now run Julia from the command line, by typing `julia`!
-@@
 
 #### Adding Julia to PATH on Windows 7 or 8
 
-@@tight-list
 1.  Open Run (Windows Key + R),  type in `rundll32 sysdm.cpl,EditEnvironmentVariables` and hit enter.
 2.  In the System Variables window, highlight Path, and click Edit.
 3.  In the Edit System Variables window, move the cursor to the end of the field.
 4.  If there is no semicolon at the end, add it and paste in the path to the `bin` folder within the installation directory noted earlier. This path should look something like \winpathbin.
 5.  Click OK. You can now run Julia from the command line, by typing `julia`!
-@@
 
 
 ### Windows 7 / Windows Server 2012 Installation Notes
 
 Windows 7 / Windows Server 2012 users also need to install:
 
-@@tight-list
 *   the [TLS easy\_fix](https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in) for the package manager to work, see [this Discourse thread](https://discourse.julialang.org/t/errors-for-git-pkg/9351) for more details.
 *   [Windows Management Framework 3.0 or later](https://docs.microsoft.com/en-us/powershell/scripting/wmf/overview) to include PowerShell 3.0 or later.
-@@
 
 ### Uninstallation
 
@@ -146,7 +139,7 @@ This automatically puts the binary into a directory in the user's PATH, so you c
 
 ## Fedora/RHEL/CentOS/SL/OEL Linux
 
-A [Copr repository](https://copr.fedoraproject.org/coprs/nalimilan/julia/) is provided for Fedora, RHEL, CentOS, Scientific Linux and Oracle Enterprise Linux systems to allow for automatic updating to the latest stable version of Julia.  On Fedora and CentOS 8, Julia is available in 
+A [Copr repository](https://copr.fedoraproject.org/coprs/nalimilan/julia/) is provided for Fedora, RHEL, CentOS, Scientific Linux and Oracle Enterprise Linux systems to allow for automatic updating to the latest stable version of Julia.  On Fedora and CentOS 8, Julia is available in
 the main repositories, and you do not need to use the Copr repository.
 
 If you are using RHEL, CentOS, Scientific Linux or Oracle Enterprise Linux (version 5 or higher), first [enable EPEL](https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F) for your distribution version. Then follow the steps below.


### PR DESCRIPTION
This applies some sensible CSS for all lists + 1-level nested lists for most pages. The use of `@@tight-list` is therefore unnecessary (though it shouldn't cause issues on page that already use it).

If a page has some weird-looking list please do the following:

1. try adding the relevant path to `_layout/head` around L17  following the examples and see if it helps
2. if (1) failed, open an issue and please assign it to me

cc @logankilpatrick , @elizavetasemenova 

closes https://github.com/tlienart/Franklin.jl/issues/838 

Notes:

- removed `@@tight-list` in a bunch of place so that people don't copy paste it as much
- fixed a few typos in `contribute/` 
- fixed the layout in the GSOD summary (latest blog post). 
- added a small note in the README about `@@tight-list` (that it's not necessary to use it anymore)