### PR TITLE
Point JuliaHub package links directly to JuliaHub package search

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@ end
 
       <br>
 
-      <p>Julia has been downloaded over 25 million times and the Julia community has registered <a href="https://juliahub.com">over 5,000 Julia packages</a> for community use.
+      <p>Julia has been downloaded over 25 million times and the Julia community has registered <a href="https://juliahub.com/ui/Packages">over 5,000 Julia packages</a> for community use.
       These include various mathematical libraries, data manipulation tools, and packages for general purpose computing. In addition to these, you can easily use libraries from <a href="https://github.com/JuliaPy/PyCall.jl">Python</a>, <a href="https://github.com/JuliaInterop/RCall.jl">R</a>, <a href="https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#Calling-C-and-Fortran-Code-1">C/Fortran</a>, <a href="https://github.com/Keno/Cxx.jl">C++</a>, and <a href="https://github.com/JuliaInterop/JavaCall.jl">Java</a>.
       If you do not find what you are looking for, ask on <a href="https://discourse.julialang.org">Discourse</a>, or even better, <a href="https://julialang.github.io/Pkg.jl/v1/">contribute one</a>!</p>
 
@@ -392,7 +392,7 @@ end
 
       <div class="row">
         <div class="col-12" style="text-align: center">
-          <a class="btn btn-sm btn-outline-danger" href="https://juliahub.com">JuliaHub: Ecosystem Pulse</a>
+          <a class="btn btn-sm btn-outline-danger" href="https://juliahub.com/ui/Packages">JuliaHub: Package Search</a>
           <a class="btn btn-sm btn-outline-danger" href="https://juliaobserver.com/">Julia Observer</a>
         </div>
       </div>

--- a/packages/index.md
+++ b/packages/index.md
@@ -3,7 +3,7 @@
 The Julia ecosystem contains over 4,000 packages that are registered in the [General registry](https://github.com/JuliaRegistries/General), which means that finding the right package can be a challenge. Fortunately, there are services that can help navigate the ecosystem, including:
 
 @@tight-list
-* [JuliaHub](https://juliahub.com) — a [Julia Computing](https://juliacomputing.com) service that includes search of all registered open source package documentation, code search, and navigation by tags/keywords.
+* [JuliaHub](https://juliahub.com/ui/Packages) — a [Julia Computing](https://juliacomputing.com) service that includes search of all registered open source package documentation, code search, and navigation by tags/keywords.
 * [Julia Observer](https://juliaobserver.com) — see what packages are popular and/or trending, navigate by package categories.
 * [Julia Packages](https://juliapackages.com) — browse Julia packages, filter by categories, and sort them by popularity, creation date or date of last update. Also supports browsing package developers.
 * [Julia.jl](https://github.com/svaksha/Julia.jl) — a manually curated taxonomy of Julia packages (category information for JuliaPackages is derived from this as well).


### PR DESCRIPTION
Previously they were pointing to https://juliahub.com, which for logged-out users redirects to https://juliahub.com/lp/, where there is no obvious path to package search. Now they point directly to the package search at https://juliahub.com/ui/Packages.

I also removed the reference to "Ecosystem Pulse", which does not appear to be present on the JuliaHub site anymore. 