### PR TITLE
Remove JuliaObserver, promote JuliaPackages

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,7 +393,6 @@ end
       <div class="row">
         <div class="col-12" style="text-align: center">
           <a class="btn btn-sm btn-outline-danger" href="https://juliahub.com/ui/Packages">JuliaHub: Package Search</a>
-          <a class="btn btn-sm btn-outline-danger" href="https://juliaobserver.com/">Julia Observer</a>
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -393,6 +393,7 @@ end
       <div class="row">
         <div class="col-12" style="text-align: center">
           <a class="btn btn-sm btn-outline-danger" href="https://juliahub.com/ui/Packages">JuliaHub: Package Search</a>
+          <a class="btn btn-sm btn-outline-danger" href="https://juliapackages.com/trending">JuliaPackages: Trending</a>
         </div>
       </div>
 

--- a/packages/index.md
+++ b/packages/index.md
@@ -4,7 +4,6 @@ The Julia ecosystem contains over 4,000 packages that are registered in the [Gen
 
 @@tight-list
 * [JuliaHub](https://juliahub.com/ui/Packages) — a [Julia Computing](https://juliacomputing.com) service that includes search of all registered open source package documentation, code search, and navigation by tags/keywords.
-* [Julia Observer](https://juliaobserver.com) — see what packages are popular and/or trending, navigate by package categories.
 * [Julia Packages](https://juliapackages.com) — browse Julia packages, filter by categories, and sort them by popularity, creation date or date of last update. Also supports browsing package developers.
 * [Julia.jl](https://github.com/svaksha/Julia.jl) — a manually curated taxonomy of Julia packages (category information for JuliaPackages is derived from this as well).
 @@


### PR DESCRIPTION
This PR removes references to JuliaObserver, which is old, slow, and only references METADATA. I saw JuliaPackages was broken so I was going to remove that, but it looks like it was working as recently as June so I expect to see it come online at some point. Thus, I replaced the JuliaObserver link on the front page with one to JuliaPackages, with the hopes it comes back online. 