### PR TITLE
Platform support table: drop support for FreeBSD 11, and keep Tier 1 support for FreeBSD 12+

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -346,7 +346,7 @@ The platforms currently supported by Julia are listed below. They are divided in
     </tr>
     <tr>
       <td rowspan="2"> FreeBSD </td>
-      <td rowspan="2"> 11.0+ </td>
+      <td rowspan="2"> 12.0+ </td>
       <td> x86-64 (64-bit) </td>
       <td> <font color="green">Tier 1</font> </td>
     </tr>


### PR DESCRIPTION
This is an alternative to the FreeBSD portion of #1344.