### PR TITLE
Update Arch Linux installation instructions

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -181,14 +181,11 @@ Recent Debian/ubuntu distributions include their own build of Julia, which can b
 sudo apt install julia
 ```
 
-## Arch Linux
-The Arch User Repository has [a package for Julia](https://aur.archlinux.org/packages/julia-bin) that is built from the official binaries of Julia. To install it run:
+## Arch Linux and Manjaro
+The Arch Community Repository has [a package for Julia](https://archlinux.org/packages/community/x86_64/julia/) to allow for installation using pacman. To install it run:
 
 ```shell
-sudo pacman -S base-devel git
-git clone https://aur.archlinux.org/julia-bin.git
-cd julia-bin
-makepkg -si
+sudo pacman -S julia
 ```
 
 ## FreeBSD Ports


### PR DESCRIPTION
Include the fact that the installation instructions are the same for Manjaro and Julia now lives in the community repository that is maintained by trusted users of Arch. See https://wiki.archlinux.org/title/official_repositories for details on different repositories in Arch.