### PR TITLE
Fail and cancel deploy on Franklin Warning

### DIFF
--- a/community/organizations.md
+++ b/community/organizations.md
@@ -4,8 +4,6 @@ Something unique about the Julia Language is the way [the community self organiz
 
 The following is a non-comprehensive list of Julia GitHub Organizations, grouped by domain:
 
-One dollar plus one dollar equals $2
-
 ### Julia
 
 * [JuliaLang](https://github.com/JuliaLang) – A fresh approach to numerical computing


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/www.julialang.org/issues/1357.

Fixes #1357

This is the hacky and quick fix. It greps the logs, for "Franklin Warning". So, this assumes that Franklin prints the text "Franklin Warning" when something bad happens. In my experience, it works quite well because any parse or runtime error will give this warning. However, note that this doesn't detect missing images and/or probably other problems. For my own blog, this grep hack has worked for a year now and works quite well. CI has failed quite a lot of times without me expecting that it would fail, which is a good thing.

Note that the output isn't printed immediately to stdout and only to `build.log`. In my experience, that's fine. The only difference is that you have to wait a few more minutes before the stdout becomes visible.

Also, I've added some whitespace between the steps for readability.