### PR TITLE
add sudo to mac symlink code

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -62,7 +62,7 @@ If you want to launch Julia from the command line, first [open a new terminal wi
 
 ~~~
 <pre><code class="language-shell">rm -f /usr/local/bin/julia
-ln -s /Applications/Julia-{{stable_release_short}}.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia</code></pre>
+sudo ln -s /Applications/Julia-{{stable_release_short}}.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia</code></pre>
 ~~~
 
 This code creates a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to a Julia version (here {{stable_release_short}}) of your choosing.


### PR DESCRIPTION
I've added a `sudo` to the front of the code to create a symlink under apple. I'm not really sure what generation of the operating system requires this, but the current one does.