### PR TITLE
Slack: add the link to the Julia Slack for users that already have a Julia Slack account

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -2,11 +2,14 @@
 
 The Julia Language has an active Slack workspace/community with over 8,000 members. Slack is a space to have quick and informal correspondence with others in the community. We ask that if you have Julia usage questions, you post them on [Discourse](https://discourse.julialang.org) so others can benefit from them. You could also use Stack Overflow but the Discourse community is much more welcoming (in our opinion).
 
-## You can find the link to join below:
+## To create a free account in the Julia Language Slack, please use the following link:
 [Join us in the Julia Language Slack](https://join.slack.com/t/julialang/shared_invite/zt-nmal0i0x-LcYEtdnTameGsXmBzMzgog)
 
 ### Issues using the link above? 
 [Send us a note so we can fix that!](mailto:logan@julialang.org)
+
+## Already have a Julia Slack account? Log in with the following link:
+[Log in to the Julia Slack](https://julialang.slack.com/)
 
 ### Admins
 The [Julia Community Standards](https://julialang.org/community/standards/) are enforced on Slack by our Slack Admins. 


### PR DESCRIPTION
We currently have a link for new users to create a Slack account.

But we don't currently have a link for existing users to log back in.