### PR TITLE
Add #julia channel on Libera to community page

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -62,7 +62,7 @@ From: https://stackoverflow.com/questions/31821974/support-user-time-zone-in-emb
      <!-- 3 -->
      <div class="col-lg-4 col-md-6 feature">
        <h3>Chat</h3>
-       <p>For casual conversations, we have an <a href="https://julialang.org/slack/">official Julia Slack</a>. As an open source alternative to Slack and home to some Julia sub-communities, we have <a href="https://julialang.zulipchat.com/register/">Zulip</a>. There is also an active community on the <a href="https://discord.gg/mm2kYjB">Humans of Julia Discord server</a>.
+       <p>For casual conversations, we have an <a href="https://julialang.org/slack/">official Julia Slack</a>. As an open source alternative to Slack and home to some Julia sub-communities, we have <a href="https://julialang.zulipchat.com/register/">Zulip</a>. There is also an active community on the <a href="https://discord.gg/mm2kYjB">Humans of Julia Discord server</a> and <a href="ircs://irc.libera.chat/julia">#julia</a> on the <a href="https://libera.chat/">Libera IRC network</a>.
        </p>
      </div>
      <!-- 4 -->


### PR DESCRIPTION
We never really left; just stayed with the network when the freenode
domain was “lost”.