### PR TITLE
Linkify the "Other Relevant Benchmark" links

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -14,6 +14,6 @@ These micro-benchmark results were obtained on a single core (serial execution) 
 
 ## Other Relevant Benchmarks
 
-- DataFrames: <https://h2oai.github.io/db-benchmark/>
-- Graphs: <https://www.timlrx.com/blog/benchmark-of-popular-graph-network-packages-v2>
-- CSV and Pandas: <https://www.queryverse.org/benchmarks/>
+- DataFrames: [https://h2oai.github.io/db-benchmark/](https://h2oai.github.io/db-benchmark/)
+- Graphs: [https://www.timlrx.com/blog/benchmark-of-popular-graph-network-packages-v2](https://www.timlrx.com/blog/benchmark-of-popular-graph-network-packages-v2)
+- CSV and Pandas: [https://www.queryverse.org/benchmarks/](https://www.queryverse.org/benchmarks/)

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -14,6 +14,6 @@ These micro-benchmark results were obtained on a single core (serial execution) 
 
 ## Other Relevant Benchmarks
 
-- DataFrames: https://h2oai.github.io/db-benchmark/
-- Graphs: https://www.timlrx.com/blog/benchmark-of-popular-graph-network-packages-v2
-- CSV and Pandas: https://www.queryverse.org/benchmarks/
+- DataFrames: <https://h2oai.github.io/db-benchmark/>
+- Graphs: <https://www.timlrx.com/blog/benchmark-of-popular-graph-network-packages-v2>
+- CSV and Pandas: <https://www.queryverse.org/benchmarks/>


### PR DESCRIPTION
This is using the "[auto link](https://github.github.com/gfm/#autolinks)" syntax defined for Github Flavored Markdown, which should be what Jekyll [uses by default](https://jekyllrb.com/docs/configuration/markdown/).