### PR TITLE
Set current stable version to 1.6.4

### DIFF
--- a/config.md
+++ b/config.md
@@ -10,9 +10,9 @@
 @def author = ""
 
 <!-- Templating of the Downloads -->
-@def stable_release = "1.6.3"
+@def stable_release = "1.6.4"
 @def stable_release_short = "1.6"
-@def stable_release_date = "Sep 23, 2021"
+@def stable_release_date = "Nov 19, 2021"
 @def lts_release = "1.0.5"
 @def lts_release_short = "1.0"
 @def lts_release_date = "Sep 9, 2019"

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -61,6 +61,7 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
           (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{stable_release_short}}/julia-{{stable_release}}-linux-armv7l.tar.gz.asc">GPG</a>)
       </td>
     </tr>
+    <!--
     <tr>
       <th> Generic Linux on PowerPC <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/ppc64le/{{stable_release_short}}/julia-{{stable_release}}-linux-ppc64le.tar.gz">64-bit (little endian)</a>
@@ -69,6 +70,7 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
       <td colspan="3">
       </td>
     </tr>
+    -->
     <tr>
       <th> Generic FreeBSD on x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{stable_release_short}}/julia-{{stable_release}}-freebsd-x86_64.tar.gz">64-bit</a>


### PR DESCRIPTION
Also comment out the stable PowerPC table entry because the buildbots seem to have been offline for months and thus no binaries.