### PR TITLE
In "Platform Specific Instructions" -> "macOS", don't recommend that the user use `sudo` when creating the symlink

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -63,7 +63,7 @@ If you want to launch Julia from the command line, first [open a new terminal wi
 ~~~
 <pre><code class="language-shell">mkdir -p /usr/local/bin
 rm -f /usr/local/bin/julia
-sudo ln -s /Applications/Julia-{{stable_release_short}}.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia</code></pre>
+ln -s /Applications/Julia-{{stable_release_short}}.app/Contents/Resources/julia/bin/julia /usr/local/bin/julia</code></pre>
 ~~~
 
 This code creates a [symlink](https://en.wikipedia.org/wiki/Symbolic_link) to a Julia version (here {{stable_release_short}}) of your choosing.


### PR DESCRIPTION
I don't think this `sudo` is actually necessary, although it would be good for someone to confirm this.