### PR TITLE
Remove "update every 24h" from download info

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -399,4 +399,4 @@ The platforms currently supported by Julia are listed below. They are divided in
 
 ## JSON release feed
 
-The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json) ([schema](https://julialang-s3.julialang.org/bin/versions-schema.json)). It may take up to an hour after the release of a new version for it to be included in the JSON file.
+The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json) ([schema](https://julialang-s3.julialang.org/bin/versions-schema.json)). It may take up to two hours after the release of a new version for it to be included in the JSON file.

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -399,4 +399,4 @@ The platforms currently supported by Julia are listed below. They are divided in
 
 ## JSON release feed
 
-The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json) ([schema](https://julialang-s3.julialang.org/bin/versions-schema.json)). The file is updated once every 24 hours.
+The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json) ([schema](https://julialang-s3.julialang.org/bin/versions-schema.json)). It may take up to an hour after the release of a new version for it to be included in the JSON file.


### PR DESCRIPTION
This is no longer true as running the build on a schedule caused issues each release. The file rebuild is triggered manually during the release process.

cc @ararslan 