### PR TITLE
Downloads: add "(experimental)" to M1 (is Tier 3)

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -34,7 +34,7 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
     </tr>
     <tr>
       <th> macOS ARM (M-series Processor) <a href="/downloads/platform/#macos">[help]</a></th>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/aarch64/{{stable_release_short}}/julia-{{stable_release}}-macaarch64.dmg">64-bit</a> </td>
+      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/aarch64/{{stable_release_short}}/julia-{{stable_release}}-macaarch64.dmg">64-bit</a> (experimental) </td>
       <td colspan="3"> </td>
     </tr>
     <tr>


### PR DESCRIPTION
The M1 build is currently the only Tier 3 download listed prominently in the downloads page, which might give the false impression that it is the latest and greatest Julia release.

I think the development of an M1 binary is fantastic, but for new users, it is more important to give a stable Julia binary, right? The x86 version works really well on M1 computers, whereas the M1 binary is giving occasional segfaults, and some `_jll` packages don't have an M1 version yet.
