### PR TITLE
Switch to JuliaMono for code blocks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,21 +46,8 @@ jobs:
 
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
-
-      # This ensures that NodeJS and Franklin are loaded then it installs
-      # highlight.js which is needed for the prerendering step.
-      # Then the environment is activated and instantiated to install all
-      # Julia packages which may be required to successfully build your site.
-      # NOTE: the last line should be `optimize()`, you may want to give it
-      # specific arguments, see the documentation or ?optimize in the REPL.
-      - name: Build site
-        run: |
-          julia --color=yes --project -e '
-              using NodeJS; run(`$(npm_cmd()) install highlight.js`);
-              using Franklin;
-              Franklin.HIGHLIGHTJS[] = abspath(joinpath("_libs", "highlight", "highlight.min.js"));
-              Franklin.optimize(prerender=true);
-              cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"))' > build.log
+      - run: |
+          julia --project -e 'using JuliaSite; build_site()' > build.log
           cat build.log
 
       - name: Validate output

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           version: 1.6
 
+      - uses: julia-actions/cache@v1
+
       # This ensures that NodeJS and Franklin are loaded then it installs
       # highlight.js which is needed for the prerendering step.
       # Then the environment is activated and instantiated to install all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.6
+          version: 1.7
 
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           version: 1.6
 
       - uses: julia-actions/cache@v1
-      - uses: julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'
+      - uses: julia-actions/julia-buildpkg@v1
 
       # This ensures that NodeJS and Franklin are loaded then it installs
       # highlight.js which is needed for the prerendering step.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
           version: 1.6
 
       - uses: julia-actions/cache@v1
+      - uses: julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'
 
       # This ensures that NodeJS and Franklin are loaded then it installs
       # highlight.js which is needed for the prerendering step.
@@ -55,7 +56,6 @@ jobs:
       - name: Build site
         run: |
           julia --color=yes --project -e '
-              using Pkg; Pkg.instantiate();
               using NodeJS; run(`$(npm_cmd()) install highlight.js`);
               using Franklin;
               Franklin.HIGHLIGHTJS[] = abspath(joinpath("_libs", "highlight", "highlight.min.js"));

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,13 @@
+[JuliaMono]
+git-tree-sha1 = "8730bd1d8cbb19f36e0ca10236011fd72083746f"
+
+    [[JuliaMono.download]]
+    sha256 = "255b4960fa61ccc58660603c3b8ae19f1cd9d10ecb34ea32967bb32381962931"
+    url = "https://github.com/cormullion/juliamono/archive/v0.042.tar.gz"
+
+[Highlight]
+git-tree-sha1 = "74d0a953af18dcd657e32a9cd95e77d791882528"
+
+    [[Highlight.download]]
+    sha256 = "ba979bd14d82065aebea450ed77e4b3fe217ca3a7876cc69606147b85d8fb3ce"
+    url = "https://github.com/highlightjs/cdn-release/archive/refs/tags/11.4.0.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -5,9 +5,3 @@ git-tree-sha1 = "8730bd1d8cbb19f36e0ca10236011fd72083746f"
     sha256 = "255b4960fa61ccc58660603c3b8ae19f1cd9d10ecb34ea32967bb32381962931"
     url = "https://github.com/cormullion/juliamono/archive/v0.042.tar.gz"
 
-[Highlight]
-git-tree-sha1 = "74d0a953af18dcd657e32a9cd95e77d791882528"
-
-    [[Highlight.download]]
-    sha256 = "ba979bd14d82065aebea450ed77e4b3fe217ca3a7876cc69606147b85d8fb3ce"
-    url = "https://github.com/highlightjs/cdn-release/archive/refs/tags/11.4.0.tar.gz"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,18 +1,18 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
 [[Artifacts]]
-deps = ["Pkg"]
-git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[Crayons]]
-git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.4"
+version = "4.1.1"
 
 [[Dates]]
 deps = ["Printf"]
@@ -22,41 +22,47 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.3"
+version = "0.8.6"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[ExprTools]]
-git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
+git-tree-sha1 = "56559bbef6ca5ea0c0818fa5c90320398a6fbf8d"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-version = "0.1.3"
+version = "0.1.8"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[Franklin]]
 deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "ExprTools", "FranklinTemplates", "HTTP", "Literate", "LiveServer", "Logging", "Markdown", "NodeJS", "OrderedCollections", "Pkg", "REPL", "Random"]
-git-tree-sha1 = "f92852d1d22d9d5f36f1ef11647718153bcfd895"
+git-tree-sha1 = "f42b7a1622802b6cdefff0dc21c971948e962e21"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
-version = "0.10.28"
+version = "0.10.66"
 
 [[FranklinTemplates]]
 deps = ["LiveServer"]
-git-tree-sha1 = "7159314a91990842cfa6484f3a0fd5666015a7c2"
+git-tree-sha1 = "acc6d580caa8d46a7669a50d0fdb0e2df09448e3"
 uuid = "3a985190-f512-4703-8d38-2a7944ed5916"
-version = "0.8.12"
+version = "0.8.24"
 
 [[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets", "URIs"]
-git-tree-sha1 = "63055ee44b5c2b95ec1921edcf856c60124ff0c3"
+deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
+git-tree-sha1 = "0fa77022fe4b511826b39c894c90daf5fce3334a"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.2"
+version = "0.9.17"
+
+[[IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.2"
 
 [[IniFile]]
 deps = ["Test"]
@@ -68,35 +74,42 @@ version = "0.5.0"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[JLLWrappers]]
-git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
-uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.2.0"
-
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.2"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Literate]]
-deps = ["Base64", "JSON", "REPL"]
-git-tree-sha1 = "32b517d4d8219d3bbab199de3416ace45010bdb3"
+deps = ["Base64", "IOCapture", "JSON", "REPL"]
+git-tree-sha1 = "a9e1c1ce0a604cf91b1698268cf05718fb4e25c8"
 uuid = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-version = "2.8.0"
+version = "2.11.0"
 
 [[LiveServer]]
 deps = ["Crayons", "FileWatching", "HTTP", "Pkg", "Sockets", "Test"]
-git-tree-sha1 = "7c2f32edab7941184a58ef56d589dac14e0ffa23"
+git-tree-sha1 = "505e296f3a4babe953d808fd944e7cffd160c407"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
-version = "0.6.0"
+version = "0.7.1"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -112,13 +125,17 @@ uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 version = "1.0.3"
 
 [[MbedTLS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
+deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+1"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[NodeJS]]
 deps = ["Pkg"]
@@ -127,18 +144,18 @@ uuid = "2bd173c7-0d6d-553b-b6af-13a54713934c"
 version = "1.1.1"
 
 [[OrderedCollections]]
-git-tree-sha1 = "d45739abcfc03b51f6a42712894a593f74c80a23"
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.3"
+version = "1.4.1"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+git-tree-sha1 = "0b5cfbb704034b5b4c1869e36634438a047df065"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.15"
+version = "2.2.1"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -146,7 +163,7 @@ deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
@@ -162,14 +179,22 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[URIs]]
-git-tree-sha1 = "7855809b88d7b16e9b029afd17880930626f54a2"
+git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.2.0"
+version = "1.3.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -177,3 +202,15 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "JuliaSite"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
 NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,3 +1,5 @@
+name = "JuliaSite"
+
 [deps]
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
 NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"

--- a/_css/app.css
+++ b/_css/app.css
@@ -542,7 +542,7 @@ blockquote p {
   margin-bottom: 0;
 }
 
-code, table.benchmarks tbody {
+table.benchmarks tbody {
   font: 9pt Monaco, 'Consolas', monospace;
 }
 

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -6,9 +6,9 @@
 
 	<link rel="icon" href="/assets/infra/julia.ico">
 
-  <!-- Franklin stylesheets for generated pages -->
-  {{if hasmath}} {{insert head_katex.html }}      {{end}}
-  {{if hascode}} {{insert head_highlight.html }}  {{end}}
+  {{if hasmath}} {{insert head_katex.html }} {{end}}
+  {{if hascode}} {{insert head_highlight.html }} {{end}}
+  {{if hascode}} {{insert juliamono.html }} {{end}}
 
 	{{insert head_scripts.html}}
 

--- a/_layout/juliamono.html
+++ b/_layout/juliamono.html
@@ -1,0 +1,11 @@
+<style>
+    @font-face {
+      font-family: JuliaMono-Regular;
+      src: url("{{artifact JuliaMono juliamono-0.042 webfonts JuliaMono-Regular.woff2}}");
+    }
+
+    code {
+        font-family: JuliaMono-Regular,SFMono-Regular,Menlo,Monaco !important;
+        font-variant-ligatures: none;
+    }
+</style>

--- a/src/JuliaSite.jl
+++ b/src/JuliaSite.jl
@@ -13,11 +13,11 @@ for the prerendering step. Then the environment is activated and instantiated to
 Julia packages which may be required to successfully build your site.
 """
 function build_site()
-    run(`$(npm_cmd()) install highlight.js`)
+    # run(`$(npm_cmd()) install highlight.js`)
     highlight_path = abspath(joinpath("_libs", "highlight", "highlight.min.js"))
     Franklin.HIGHLIGHTJS[] = highlight_path
     Franklin.optimize(; prerender=true)
-    cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"))
+    cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"); force=true)
 end
 
 end # module

--- a/src/JuliaSite.jl
+++ b/src/JuliaSite.jl
@@ -17,7 +17,7 @@ function build_site()
     highlight_path = abspath(joinpath("_libs", "highlight", "highlight.min.js"))
     Franklin.HIGHLIGHTJS[] = highlight_path
     Franklin.optimize(; prerender=true)
-    cp(joinpath("__site", "feed.xml"), joinpath("__size", "index.xml"))
+    cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"))
 end
 
 end # module

--- a/src/JuliaSite.jl
+++ b/src/JuliaSite.jl
@@ -1,7 +1,10 @@
 module JuliaSite
 
+using Artifacts: @artifact_str
 using NodeJS
 using Franklin
+
+artifact"JuliaMono"
 
 export build_site
 

--- a/src/JuliaSite.jl
+++ b/src/JuliaSite.jl
@@ -1,0 +1,23 @@
+module JuliaSite
+
+using NodeJS
+using Franklin
+
+export build_site
+
+"""
+    build_site()
+
+This ensures that NodeJS and Franklin are loaded then it installs highlight.js which is needed
+for the prerendering step. Then the environment is activated and instantiated to install all
+Julia packages which may be required to successfully build your site.
+"""
+function build_site()
+    run(`$(npm_cmd()) install highlight.js`)
+    highlight_path = abspath(joinpath("_libs", "highlight", "highlight.min.js"))
+    Franklin.HIGHLIGHTJS[] = highlight_path
+    Franklin.optimize(; prerender=true)
+    cp(joinpath("__site", "feed.xml"), joinpath("__size", "index.xml"))
+end
+
+end # module

--- a/utils.jl
+++ b/utils.jl
@@ -12,7 +12,7 @@ variable should be given as an iterable of 3-tuples like so:
 ```
 A full example can be found in `blog/2020/05/rr.md`.
 """
-function hfun_meta()
+@delay function hfun_meta()
     title = locvar(:title)
     isnothing(title) && (title = "The Julia Language")
     descr = locvar(:rss)
@@ -46,7 +46,7 @@ end
 
 Plug in the list of blog posts contained in the `/blog/` folder.
 """
-function hfun_blogposts()
+@delay function hfun_blogposts()
     curyear = year(Dates.today())
     io = IOBuffer()
     for year in curyear:-1:2012
@@ -64,7 +64,7 @@ function hfun_blogposts()
                 url = "/blog/$ys/$ms/$ps/"
                 surl = strip(url, '/')
                 title = pagevar(surl, :title)
-				title === nothing && (title = "Untitled")
+                title === nothing && (title = "Untitled")
                 pubdate = pagevar(surl, :published)
                 if isnothing(pubdate)
                     date    = "$ys-$ms-01"
@@ -90,7 +90,7 @@ end
 
 Input the 3 latest blog posts.
 """
-function hfun_recentblogposts()
+@delay function hfun_recentblogposts()
     curyear = Dates.Year(Dates.today()).value
     ntofind = 3
     nfound  = 0
@@ -127,7 +127,7 @@ function hfun_recentblogposts()
     for (surl, date) in recent
         url   = "/$surl/"
         title = pagevar(surl, :title)
-		title === nothing && (title = "Untitled")
+        title === nothing && (title = "Untitled")
         sdate = "$(day(date)) $(monthname(date)) $(year(date))"
         blurb = pagevar(surl, :rss)
         write(io, """
@@ -183,7 +183,7 @@ end
 """
     {{about_the_author}}
 """
-function hfun_about_the_author()
+@delay function hfun_about_the_author()
 	# verify that author_img and author_blurb are given
     any(isnothing ∘ locvar, (:author_img, :author_blurb)) && return ""
 	img = "/assets/$(locvar(:author_img))"
@@ -215,7 +215,7 @@ function hfun_about_the_author()
     return html
 end
 
-function hfun_all_gsoc_projects()
+@delay function hfun_all_gsoc_projects()
 	base_dir = joinpath("jsoc", "gsoc")
 	all_projects = readdir(base_dir)
 	md = IOBuffer()

--- a/utils.jl
+++ b/utils.jl
@@ -1,3 +1,4 @@
+using Artifacts: @artifact_str
 using Dates
 
 """
@@ -227,3 +228,27 @@ function hfun_all_gsoc_projects()
 	allmd = String(take!(md))
 	return fd2html(allmd, internal=true)
 end
+
+"""
+    hfun_artifact(params::Vector{String})::String
+
+Return a (relative) URL to an artifact.
+For example, for JuliaMono, use
+```
+{{artifact JuliaMono juliamono-0.042 webfonts JuliaMono-Regular.woff2}}
+```
+where JuliaMono is the name of the Artifact in Artifacts.toml.
+This method copies the artifact, puts it into `_assets` and returns a relative URL.
+"""
+function hfun_artifact(params::Vector{String})::String
+    name = params[1]
+    dir = @artifact_str(name)
+    from = joinpath(dir, params[2:end]...)
+    @assert isfile(from)
+    location = params[2:end]
+    to = joinpath(@__DIR__, "__site", "assets", name, location...)
+    mkpath(dirname(to))
+    cp(from, to; force=true)
+    return string('/', join(["assets"; name; location], '/'))
+end
+


### PR DESCRIPTION
This PR is a shot at #1272. Benefits of using this font that I can think of are more consistent appearance because this ensures that the font is available and coolness because it is JuliaMono. Drawback is slower page loading because the font has to be downloaded.

I also propose to use the Artifacts system instead of storing the files in the repo or using a CDN. CDNs are pretty useless because browsers do not cache the same thing if it comes from different domains for security reasons (https://httptoolkit.tech/blog/public-cdn-risks/). Even worse, CDNs are bad for privacy and may slow the page down due to an extra DNS lookup.

## Preview

The preview is at zoom level 100% because that's probably how most people read the page. The screenshot is from a code block at https://julialang.org/blog/2021/10/DEQ/.

### Consolas (current monospace font)

![image](https://user-images.githubusercontent.com/20724914/151705328-f07e0cab-ad84-4e3d-938d-091b2b7a6691.png)

### JuliaMono

![image](https://user-images.githubusercontent.com/20724914/151705286-1ec54db3-38e2-4d4a-a9c7-ae7fc2235793.png)
