### PR TITLE
Link topopt page in jsoc projects

### DIFF
--- a/jsoc/projects.md
+++ b/jsoc/projects.md
@@ -28,6 +28,7 @@ We have our project ideas organized below roughly by domain but you can also see
 * [TableTransforms.jl](/jsoc/gsoc/tabletransforms/) - Tabular transforms used in statistics and machine learning
 * [Turing](/jsoc/gsoc/turing/) - for probabilistic modelling and probabilistic programming
 * [VS Code](/jsoc/gsoc/vscode/) - Improving Julia's VS Code IDE experience
+* [Topology optimisation](/jsoc/gsoc/topopt/) - improving topology optimisation tools in Julia.
 @@
 
 We also have Julia project's available under other organizations. If you are applying for those projects, make sure your application is for that organization and NOT the Julia Language:


### PR DESCRIPTION
This PR complements #1521 by linking the page on the projects list.