### PR TITLE
GSoC: fix link to wasm page

### DIFF
--- a/jsoc/projects.md
+++ b/jsoc/projects.md
@@ -33,6 +33,7 @@ We have our project ideas organized below roughly by domain but you can also see
 * [Turing](/jsoc/gsoc/turing/) - for probabilistic modelling and probabilistic programming
 * [VS Code](/jsoc/gsoc/vscode/) - Improving Julia's VS Code IDE experience
 * [Topology optimisation](/jsoc/gsoc/topopt/) - improving topology optimisation tools in Julia.
+* [WebAssembly](/jsoc/gsoc/wasm/) - running and compiling Julia on WebAssembly
 @@
 
 We also have Julia project's available under other organizations. If you are applying for those projects, make sure your application is for that organization and NOT the Julia Language:


### PR DESCRIPTION
It looks like the link to WASM projects (https://julialang.org/jsoc/gsoc/wasm/) got lost somehow... This PR fixes it!

WASM development is hugely important to the Pluto team, so it would be fantastic to get a GSoC student on it! I removed the iodide-integration project recently (#1491), but the rest is all still up-to-date. 👍