### PR TITLE
make expected results explicit in web app project

### DIFF
--- a/jsoc/gsoc/gui.md
+++ b/jsoc/gsoc/gui.md
@@ -20,13 +20,15 @@ The [QML.jl](https://github.com/barche/QML.jl) package provides Julia bindings f
 [Makie.jl](https://github.com/JuliaPlots/Makie.jl) is a visualization ecosystem for the Julia programming language, with a focus on interactivity and performance.
 [JSServe.jl](https://github.com/SimonDanisch/JSServe.jl) is the core infrastructure library that makes Makie's web-based backend possible.
 
-At the moment, all the necessary ingredients exist for designing web-based User Interfaces (UI) in Makie, but the process itself is quite low-level and time-consuming.
-The aim of this project is to streamline that process via the following steps:
-- implementing novel UI components and refining existing ones,
-- introducing data structures suitable for representing complex UIs,
-- adding simpler syntaxes for common scenarios, akin to Interact's [`@manipulate`](https://github.com/JuliaGizmos/Interact.jl#manipulate) macro,
-- improving documentation and tutorials,
-- streamlining the deployment process.
+At the moment, all the necessary ingredients exist for designing web-based User Interfaces (UI) in Makie, but the process itself is quite low-level and time-consuming. The aim of this project is to streamline that process.
+
+### Expected results
+
+- Implement novel UI components and refine existing ones.
+- Introduce data structures suitable for representing complex UIs.
+- Add simpler syntaxes for common scenarios, akin to Interact's [`@manipulate`](https://github.com/JuliaGizmos/Interact.jl#manipulate) macro.
+- Improve documentation and tutorials.
+- Streamline the deployment process.
 
 **Bonus tasks.** If time allows, one of the following directions could be pursued.
 1. Making Makie web-based plots more suitable for general web apps (move more computation to the client side, improve interactivity and responsiveness).

--- a/jsoc/gsoc/gui.md
+++ b/jsoc/gsoc/gui.md
@@ -31,7 +31,7 @@ At the moment, all the necessary ingredients exist for designing web-based User 
 - Streamline the deployment process.
 
 **Bonus tasks.** If time allows, one of the following directions could be pursued.
-1. Making Makie web-based plots more suitable for general web apps (move more computation to the client side, improve interactivity and responsiveness).
+1. Make Makie web-based plots more suitable for general web apps (move more computation to the client side, improve interactivity and responsiveness).
 2. Generalize the UI infrastructure to native widgets, which are already implemented in Makie but with a different interface.
 
 **Desired skills.** Familiarity with HTML, JavaScript, and CSS, as well as reactive programming. Experience with the Julia visualization and UI ecosystem.


### PR DESCRIPTION
Just a small change to make the "expected results" section explicit (before the expected results were there, but the section had no name).

CC: @SimonDanisch 