### PR TITLE
Set upcoming release to 1.8.0-beta1

### DIFF
--- a/config.md
+++ b/config.md
@@ -23,7 +23,7 @@
 <!--
 If the following lines are commented, the "upcoming release" section
 in `downloads/index.md` will not be shown.
-@def upcoming_release = "1.7.0-rc3"
-@def upcoming_release_short = "1.7"
-@def upcoming_release_date = "November 15, 2021"
 -->
+@def upcoming_release = "1.8.0-beta1"
+@def upcoming_release_short = "1.8"
+@def upcoming_release_date = "February 23, 2022"

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -217,8 +217,8 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-aarch64.tar.gz">64-bit (AArch64)</a>
         (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-aarch64.tar.gz.asc">GPG</a>)
       </td>
-      <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
-                                       (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-armv7l.tar.gz.asc">GPG</a>)
+      <td colspan="3"> <!-- <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+                                       (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-armv7l.tar.gz.asc">GPG</a>) -->
       </td>
       </td>
     </tr>


### PR DESCRIPTION
Also comment out ARMv7 for upcoming since we don't have it. Note that the date in config.md reflects the date in the REPL banner, i.e. the date of the tagged commit, rather than today's date.