### PR TITLE
Fix link to upcoming release download

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -174,7 +174,7 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
 {{ifdef upcoming_release}}
 
 ~~~
-<h2><a href="#upcoming_release">Upcoming release: v{{upcoming_release}} ({{upcoming_release_date}})</a></h2>
+<h2 id=upcoming_release><a href="#upcoming_release">Upcoming release: v{{upcoming_release}} ({{upcoming_release_date}})</a></h2>
 ~~~
 
  We're currently testing release candidates for Julia v{{upcoming_release_short}}, an upcoming minor release in the 1.x series of releases. We encourage developers and interested users to try it out and report any issues they encounter. As a prerelease, it should not be considered production-ready; it's intended to give users a chance to try out {{upcoming_release_short}} with their code before the full release.


### PR DESCRIPTION
Clicking on the https://julialang.org/downloads/#upcoming_release currently does not lead to adequate position in the page. This fixes that.