### PR TITLE
Set stable release to 1.7.3, comment out macOS M1

### DIFF
--- a/config.md
+++ b/config.md
@@ -10,9 +10,9 @@
 @def author = ""
 
 <!-- Templating of the Downloads -->
-@def stable_release = "1.7.2"
+@def stable_release = "1.7.3"
 @def stable_release_short = "1.7"
-@def stable_release_date = "Feb 6, 2022"
+@def stable_release_date = "May 6, 2022"
 @def lts_release = "1.6.6"
 @def lts_release_short = "1.6"
 @def lts_release_date = "March 28, 2022"

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -32,11 +32,13 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/{{stable_release_short}}/julia-{{stable_release}}-mac64.dmg">64-bit (.dmg)</a>, <a href="https://julialang-s3.julialang.org/bin/mac/x64/{{stable_release_short}}/julia-{{stable_release}}-mac64.tar.gz">64-bit (.tar.gz)</a> </td>
       <td colspan="3"> </td>
     </tr>
+    <!--
     <tr>
       <th> macOS ARM (M-series Processor) <a href="/downloads/platform/#macos">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/aarch64/{{stable_release_short}}/julia-{{stable_release}}-macaarch64.dmg">64-bit</a> (experimental) </td>
       <td colspan="3"> </td>
     </tr>
+    -->
     <tr>
       <th> Generic Linux on x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3">


### PR DESCRIPTION
As usual the date in the config file is set to match the REPL banner rather than today's date.

We don't have macOS M1 binaries for this release.