### PR TITLE
Put the 2022 playlist on the landing page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 
 <body>
 
+  <!--
   <div class="container-fluid" id="top-alert">
     <div class="alert alert-dark alert-dismissible mb-0" role="alert">
 
@@ -23,8 +24,8 @@
       </button>
     </div>
   </div>
+  -->
 
-	
   {{insert navbar.html}}
 
   <!--
@@ -358,7 +359,7 @@ end
           }
         </script>
       </div> -->
-	<iframe width="100%" height="450px" src="https://www.youtube-nocookie.com/embed/2FHmZlTH4lg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>    
+	<iframe width="100%" height="450px" src="https://www.youtube-nocookie.com/embed/f7awOW3IHW8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
 
     <div class="row">

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@ end
 
     <div class="row">
 <!--       <div class="col-lg-8 col-md-8 video">
-        <meta name="description" content="Watch what unfolded at JuliaCon 2021 here. The latest developments, optimizations, and features happen right here, at JuliaCon."/>
+        <meta name="description" content="Watch what unfolded at JuliaCon 2022 here. The latest developments, optimizations, and features happen right here, at JuliaCon."/>
 
         <div class="embed-responsive embed-responsive-16by9"><div id="player"></div></div>
         <script type="text/javascript">
@@ -343,7 +343,7 @@ end
           function onYouTubeIframeAPIReady() {
             player = new YT.Player('player', {
               playerVars: {
-                list: 'PLP8iPy9hna6Q343_8sSq4f306VGLW4TLK',
+                list: 'PLP8iPy9hna6TRg6qJaBLJ-FRMi9Cp7gSX',
                 listType: 'playlist',
               },
               events: {
@@ -359,13 +359,13 @@ end
           }
         </script>
       </div> -->
-	<iframe width="100%" height="450px" src="https://www.youtube-nocookie.com/embed/f7awOW3IHW8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+	<iframe width="100%" height="450px" src="https://www.youtube-nocookie.com/embed/Okn_HKihWn8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
 
     <div class="row">
       <div class="col-12 text-center">
         <a class="btn btn-sm btn-outline-primary" href="https://www.youtube.com/user/JuliaLanguage">Julia Channel on YouTube</a>
-        <a class="btn btn-sm btn-outline-primary" href="https://www.youtube.com/embed/videoseries?list=PLP8iPy9hna6Tl2UHTrm4jnIYrLkIcAROR">JuliaCon 2021 videos</a>
+        <a class="btn btn-sm btn-outline-primary" href="https://www.youtube.com/embed/videoseries?list=PLP8iPy9hna6TRg6qJaBLJ-FRMi9Cp7gSX">JuliaCon 2022 videos</a>
       </div>
     </div>
           <br>


### PR DESCRIPTION
The video window looks really weird. @logankilpatrick @shashi Do either of you know how to fix it? BTW, it looks equally ugly on julialang.org now too.

Also, it no longer shows a random JuliaCon video and just the one. Which is quite terrible. Can we make the old thing work somehow?