### PR TITLE
Remove the link to `status.julialang.org` from the footer

### DIFF
--- a/_layout/foot_general.html
+++ b/_layout/foot_general.html
@@ -38,7 +38,6 @@
         <li><a href="https://github.com/JuliaLang/julia">Source Code</a></li>
         <li><a href="/downloads/#current_stable_release">Current Stable Release</a></li>
         <li><a href="/downloads/#long_term_support_release">Longterm Support Release</a></li>
-        <li><a href="https://status.julialang.org/">PkgServer Status</a></li>
       </ul>
       <ul>
         <li><a href="https://docs.julialang.org/en/v1/">Documentation</a></li>


### PR DESCRIPTION
`status.julialang.org` has frequent downtime. It's not up reliably enough for us to advertise it on the Julia website.