### PR TITLE
RFC: AMD ROCm (and oneAPI) higher tier?

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -358,12 +358,12 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
     <tr>
       <td> ROCM </td>
       <td> <a href="https://juliagpu.org/rocm">AMD ROCM (64-bit)</a> </td>
-      <td> <font color="crimson">Tier 3</font> </a> </td>
+      <td> <font color="crimson">Tier 1</font> </a> </td>
     </tr>
     <tr>
       <td> oneAPI </td>
       <td> <a href="https://juliagpu.org/oneapi">Intel oneAPI (64-bit)</a> </td>
-      <td> <font color="crimson">Tier 3</font> </a> </td>
+      <td> <font color="crimson">Tier 2</font> </a> </td>
     </tr>
     <tr>
       <td rowspan="1"> Linux (Musl) </td>


### PR DESCRIPTION
I'm not sure who controls this @jpsamaroo, but none of the tiers (or the descriptions) apply to GPUs in a strict sense(?), i.e. not about building/compiling Julia.

So it's just about "vote of confidence", and I understand ROCm support is much improved.

Don't merged without consulting, maybe ROCm should go (one) lower and oneAPI's tier just a guess.