### PR TITLE
On the Downloads page, distinguish between the Git tag date and the official release announcement date

### DIFF
--- a/config.md
+++ b/config.md
@@ -12,10 +12,12 @@
 <!-- Templating of the Downloads -->
 @def stable_release = "1.8.1"
 @def stable_release_short = "1.8"
-@def stable_release_date = "September 6, 2022"
+@def stable_release_tag_date = "September 6, 2022" # Date that the Git tag was created on GitHub
+@def stable_release_announce_date = "September TBA, 2022" # Date that the announcement was posted in the "Announcements" category on Discourse
 @def lts_release = "1.6.7"
 @def lts_release_short = "1.6"
-@def lts_release_date = "July 19, 2022"
+@def lts_release_tag_date = "July 19, 2022" # Date that the Git tag was created on GitHub
+@def lts_release_announce_date = "July 20, 2022" # Date that the announcement was posted in the "Announcements" category on Discourse
 
 <!-- plotly -->
 @def hasplotly = false

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -13,10 +13,10 @@ IF YOU'RE THINKING ABOUT REMOVING THIS NOTE, DON'T. ACCORDING TO OUR LAWYERS, TH
 -->
 
 ~~~
-<h2 id=current_stable_release><a href="#current_stable_release">Current stable release: v{{stable_release}} ({{stable_release_date}})</a></h2>
+<h2 id=current_stable_release><a href="#current_stable_release">Current stable release: v{{stable_release}}</a></h2>
 ~~~
 
-Checksums for this release are available in both [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{stable_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{stable_release}}.sha256) formats.
+Julia {{stable_release}} was tagged on {{stable_release_tag_date}} and released on {{stable_release_announce_date}}. Checksums for this release are available in both [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{stable_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{stable_release}}.sha256) formats.
 
 @@row @@col-12
 ~~~
@@ -98,11 +98,10 @@ You should *only* be using the long-term support (LTS) version of Julia if you w
 
 
 ~~~
-<h2 id=long_term_support_release><a href="#long_term_support_release">Long-term support (LTS) release: v{{lts_release}} ({{lts_release_date}})</a></h2>
+<h2 id=long_term_support_release><a href="#long_term_support_release">Long-term support (LTS) release: v{{lts_release}}</a></h2>
 ~~~
 
-Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.sha256) formats.
-
+Julia {{lts_release}} was tagged on {{lts_release_tag_date}} and released on {{lts_release_announce_date}}. Checksums for this release are available in both, [MD5](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.md5) and [SHA256](https://julialang-s3.julialang.org/bin/checksums/julia-{{lts_release}}.sha256) formats.
 
 @@row @@col-12
 ~~~


### PR DESCRIPTION
Users often confuse the date of the Git tag with the date of the official release announcement. For a recent example, see [this Discourse thread](https://discourse.julialang.org/t/unable-to-download-julia-1-8-1/87027). However, I have seen this same confusion multiple times in the past.

Therefore, on the downloads page, we should explicitly distinguish between the Git tag date and the official release announcement date.