### PR TITLE
Update outdated Actions and syntax for variable definition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -36,7 +36,7 @@ jobs:
       # matplotlib which is necessary if you intend to use PyPlot. If you do
       # not, then you can remove the `run: pip install matplotlib` line.
       - name: Install python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -73,17 +73,17 @@ jobs:
 
       - name: Deploy (preview)
         if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name # if this build is a PR build and the PR is NOT from a fork
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
-          BRANCH: gh-preview
-          FOLDER: __site
-          SSH: true
-          TARGET_FOLDER: "previews/PR${{ github.event.number }}"
+          branch: gh-preview
+          folder: __site
+          ssh-key: true
+          target-folder: "previews/PR${{ github.event.number }}"
 
       - name: Deploy (main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          SSH: true
-          BRANCH: gh-pages
-          FOLDER: __site
+          ssh-key: true
+          branch: gh-pages
+          folder: __site

--- a/config.md
+++ b/config.md
@@ -1,33 +1,31 @@
-<!-- RSS parameters -->
-@def generate_rss = true
-@def website_title = "JuliaLang - The Julia programming language"
-@def website_descr = "Official website for the Julia programming language."
-@def website_url = get(ENV, "JULIA_FRANKLIN_WEBSITE_URL", "https://julialang.org/")
-@def prepath = get(ENV, "JULIA_FRANKLIN_PREPATH", "")
++++
+# RSS parameters
+generate_rss = true
+website_title = "JuliaLang - The Julia programming language"
+website_descr = "Official website for the Julia programming language."
+website_url = get(ENV, "JULIA_FRANKLIN_WEBSITE_URL", "https://julialang.org/")
+prepath = get(ENV, "JULIA_FRANKLIN_PREPATH", "")
 
-<!-- NOTE: don't change what's below -->
-@def div_content = "container main" <!-- instead of franklin-content -->
-@def author = ""
+# NOTE: don't change what's below
+div_content = "container main"  # instead of franklin-content
+author = ""
 
-<!-- Templating of the Downloads -->
-<!--
-NOTE: When updating for a new release, make sure to also rerun
-`downloads/oldreleases.jl`
--->
-@def stable_release = "1.8.3"
-@def stable_release_short = "1.8"
-@def stable_release_date = "November 14, 2022"
-@def lts_release = "1.6.7"
-@def lts_release_short = "1.6"
-@def lts_release_date = "July 19, 2022"
+# Templating of the Downloads
+# NOTE: When updating for a new release, make sure to also rerun
+# `downloads/oldreleases.jl`
+stable_release = "1.8.3"
+stable_release_short = "1.8"
+stable_release_date = "November 14, 2022"
+lts_release = "1.6.7"
+lts_release_short = "1.6"
+lts_release_date = "July 19, 2022"
 
-<!-- plotly -->
-@def hasplotly = false
+# plotly
+hasplotly = false
 
-<!--
-If the following lines are commented, the "upcoming release" section
-in `downloads/index.md` will not be shown.
--->
-@def upcoming_release = "1.9.0-alpha1"
-@def upcoming_release_short = "1.9"
-@def upcoming_release_date = "November 15, 2022"
+# If the following lines are commented, the "upcoming release" section
+# in `downloads/index.md` will not be shown.
+upcoming_release = "1.9.0-alpha1"
+upcoming_release_short = "1.9"
+upcoming_release_date = "November 15, 2022"
++++


### PR DESCRIPTION
1. Franklin `v0.9.5` and above supports and encourages using the `toml`-like style for variable definitions. The old `@def` style is going to be deprecated soon.
2. There were a few outdated actions which have been updated along with their syntax.