### PR TITLE
blog: 2019: 07: multithreading: fix typo in variable name

### DIFF
--- a/blog/2019/07/multithreading-zh-cn.md
+++ b/blog/2019/07/multithreading-zh-cn.md
@@ -297,8 +297,8 @@ function psort!(v, lo::Int=1, hi::Int=length(v), temps=[similar(v, 0) for i = 1:
 
 ```julia
     temp = temps[Threads.threadid()]
-    length(temp) < m-lo+1 && resize!(temp, m-lo+1)
-    copyto!(temp, 1, v, lo, m-lo+1)
+    length(temp) < mid-lo+1 && resize!(temp, mid-lo+1)
+    copyto!(temp, 1, v, lo, mid-lo+1)
 ```
 
 经过这些细微的修改后，让我们测试一下程序在大规模机器上的性能:

--- a/blog/2019/07/multithreading.md
+++ b/blog/2019/07/multithreading.md
@@ -335,8 +335,8 @@ and resize it as needed:
 
 ```julia
     temp = temps[Threads.threadid()]
-    length(temp) < m-lo+1 && resize!(temp, m-lo+1)
-    copyto!(temp, 1, v, lo, m-lo+1)
+    length(temp) < mid-lo+1 && resize!(temp, mid-lo+1)
+    copyto!(temp, 1, v, lo, mid-lo+1)
 ```
 
 After these minor modifications, let's check performance on our large


### PR DESCRIPTION
The `m` variable is not defined. It should be `mid` instead.
Fixes #1763.