### PR TITLE
promote Win32 back to tier 1

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -316,7 +316,7 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
     </tr>
     <tr>
       <td> i686 (32-bit) </td>
-      <td> <font color="orange">Tier 2</font> </td>
+      <td> <font color="green">Tier 1</font> </td>
     </tr>
     <tr>
       <td> 8.1+ </td>


### PR DESCRIPTION
We have not had CI issues in a fairly long time[^1], and we do expect it to work and be tested at all times still.

[^1]: https://github.com/JuliaLang/www.julialang.org/commit/55ff318eec7e09e269a3229508e6621f14f9d004