### PR TITLE
remove deprecated link

### DIFF
--- a/jsoc/index.md
+++ b/jsoc/index.md
@@ -130,7 +130,6 @@ The Julia language organization puts out a call for proposals from the community
 There are no restrictions on what the funding can be used for. Code development, documentation work, educational, sustainability, and diversity initiatives, or other types of projects are all eligible.
 
 Since only one application can be put in for the Julia project, an internal selection process is used to determine which proposals will be submitted to NumFOCUS.
-For examples of grants that were funded in the first round, [previous awards](https://numfocus.org/programs/sustainability#sdg).
 
 Usually, around USD 5,000 - 10,000 is available per proposal.
 The total allocated funding from NumFOCUS is around USD 20,000 - 50,000 in previous cycles, meaning that not every project will be able to receive a grant.


### PR DESCRIPTION
The link used (https://numfocus.org/programs/sustainability#sdg) shows no results. I would therefore scrap in and rely on the "Check out the NumFOCUS website Small Grants section for more details" section, mentioning a link (https://numfocus.org/programs/small-development-grants) where "Previously Funded Programs" can also be found.

It could be considered to include the link to the mentioned "Previously Funded Programs" to replace for the information lost by having a second mention (https://numfocus.org/programs/small-development-grants#Previously%20Funded%20Programs).