### PR TITLE
add /gh enpoint that redirects to GitHub repo

### DIFF
--- a/gh/index.html
+++ b/gh/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Refresh" content="0; url='https://github.com/JuliaLang/julia'" />
+    <title>Redirect to GitHub Repo</title>
+  </head>
+  <body>
+    You should be redirected to <a href="https://github.com/JuliaLang/julia">https://github.com/JuliaLang/julia</a> (if not, just click the link).
+  </body>
+</html>


### PR DESCRIPTION
This is slightly odd since it's just a redirect, but I find myself typing https://github.com/JuliaLang/julia into the browser bar quite often and it's a bit painful to type. Today I accidentally started typing https://julialang.org instead, which is actually easier to type (less awkward on the fingers), and thought "Hey, wouldn't it be nice if there was a short julialang.org URL that would redirect me to GitHub?" So that's what this is: you can go to https://julialang.org/gh and it will send you to the Julia GitHub repo.
