### PR TITLE
Uncomment PowerPC for stable and upcoming releases

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -59,7 +59,6 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
       </td>
       </td>
     </tr>
-    <!--
     <tr>
       <th> Generic Linux on PowerPC <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/ppc64le/{{stable_release_short}}/julia-{{stable_release}}-linux-ppc64le.tar.gz">64-bit (little endian)</a>
@@ -68,7 +67,6 @@ Checksums for this release are available in both [MD5](https://julialang-s3.juli
       <td colspan="3">
       </td>
     </tr>
-    -->
     <tr>
       <th> Generic FreeBSD on x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{stable_release_short}}/julia-{{stable_release}}-freebsd-x86_64.tar.gz">64-bit</a>
@@ -222,7 +220,6 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
       </td>
       </td>
     </tr>
-    <!--
     <tr>
       <th> Generic Linux on PowerPC <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/ppc64le/{{upcoming_release_short}}/julia-{{upcoming_release}}-linux-ppc64le.tar.gz">64-bit (little endian)</a>
@@ -231,7 +228,6 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
       <td colspan="3">
       </td>
     </tr>
-    -->
     <tr>
       <th> Generic FreeBSD on x86 <a href="/downloads/platform/#linux_and_freebsd">[help]</a></th>
       <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/{{upcoming_release_short}}/julia-{{upcoming_release}}-freebsd-x86_64.tar.gz">64-bit</a>


### PR DESCRIPTION
The PowerPC builds on buildkite for 1.8+ are set not to allow failure, so we actually have PPC binaries. The script that prepares the release binaries was skipping it since the directory naming scheme changed with the move to buildkite so the script thought they didn't exist. I've uploaded the 1.8.5 and 1.9.0-beta2 PPC binaries and updated checksums, now this PR uncomments PPC for those versions on the downloads page. Note that 1.6 does not have PPC binaries so the LTS section still has PPC commented out.