### PR TITLE
#1815 Issue Fixed : Table formatted

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -305,7 +305,7 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
       <td> <font color="crimson">Tier 3</font> </td>
     </tr>
     <tr>
-      <td rowspan="4"> Windows </td>
+      <td rowspan="3"> Windows </td>
       <td rowspan="2"> 10+ </td>
       <td> x86-64 (64-bit) </td>
       <td> <font color="green">Tier 1</font> </td>


### PR DESCRIPTION
Fixed : #1815 Issue

The "rowspan" of Windows is mistakenly written as 4, which distorted the format of the table on Download Page. So, on change the "rowspan" to 3. Hooray! Table formatted.

@[**logankilpatrick**](https://github.com/logankilpatrick) **...** Please review my PR. and consider it to Marge.