### PR TITLE
#1831 : JSoC Updated for 2021-22

### DIFF
--- a/jsoc/archive.md
+++ b/jsoc/archive.md
@@ -2,19 +2,30 @@
 
 # Summer of Code Archives
 
-Julia has greatly benefited from the Google Summer of Code. In the last 6 years, over 70+ students have contributed to Julia and various Julia packages. Many of these students have become regular Julia contributors well beyond their summer projects. Take a look at the [Ideas Page](/jsoc) and contribute your ideas.
+Julia has greatly benefited from the Google Summer of Code. In the last 8 years, over 110+ students have contributed to Julia and various Julia packages. Many of these students, after their summer projects, have gone on to become regular contributors to Julia, a programming language that has been gaining much popularity in recent years.
+Take a look to our [Julia Seasons of Contributions Page](/jsoc) and contribute your ideas.
+
+## GSoC 2022
+
+In 2022, we are delighted to recognize Google for their support and funding, as well as our Contributor. Nineteen talented and driven students contributed to the projects, making a meaningful impact. Check out the [Projects List](https://summerofcode.withgoogle.com/archive/2022/organizations/the-julia-language#projects-list).
+
+For the 2022 idea list, [View Idea List](https://julialang.org/jsoc/projects/).
+
+## GSoC 2021
+
+In 2021, Google provided great support to our contributors through its program. 20 students contributed to Julia projects: [View Projects](https://summerofcode.withgoogle.com/archive/2021/organizations/5086646441082880#projects-list).
+
+Here is the [Idea List](https://julialang.org/jsoc/projects/).
 
 ## GSoC 2020
 
-In 2020, we are grateful to Google and the GSoC program for funding [16 awesome  students working on Julia projects](https://summerofcode.withgoogle.com/archive/2020/organizations/6163109162516480/#projects). In addition to the funding from Google, we [funded an additional 9 students](https://discourse.julialang.org/t/julia-seasons-of-contributions-to-supplement-gsoc-2020/38754) for the summer. 2020 was also the first year of the MLH Fellowship where we had 11 students working on Julia projects across the ecosystem. You can find out more about the 2020 Julia Season of Contributions [on our blog](https://julialang.org/blog/2020/09/gsoc-2020-wrapup/). 
-
+In 2020, we are grateful to Google and the GSoC program for funding [16 awesome  students working on Julia projects](https://summerofcode.withgoogle.com/archive/2020/organizations/6163109162516480/#projects). In addition to the funding from Google, we [funded an additional 9 students](https://discourse.julialang.org/t/julia-seasons-of-contributions-to-supplement-gsoc-2020/38754) for the summer. 2020 was also the first year of the MLH Fellowship where we had 11 students working on Julia projects across the ecosystem. You can find out more about the 2020 Julia Season of Contributions [on our blog](https://julialang.org/blog/2020/09/gsoc-2020-wrapup/).
 
 ## GSoC 2019
 
-In 2019, we received an even larger number of very high quality applications but could only fulfill 15 slots through GSoC. Not wanting to lose some very impressive students and their exciting projects, we decided to supplement the program with the Julia Season of Contributions (JSoC), using some community funds. Details on the program were announced here: [https://discourse.julialang.org/t/julia-seasons-of-contributions-to-supplement-gsoc/23922](https://discourse.julialang.org/t/julia-seasons-of-contributions-to-supplement-gsoc/23922)
+In 2019, we received an even larger number of very high quality applications but could only fulfill 15 slots through GSoC. Not wanting to lose some very impressive students and their exciting projects, we decided to supplement the program with the Julia Season of Contributions (JSoC), using some community funds. Details on the program were announced here: [Discourse.julialang : Julia Seasons of Contributions to supplement GSoC](https://discourse.julialang.org/t/julia-seasons-of-contributions-to-supplement-gsoc/23922)
 
-[Here is a list of all the projects for GSoC and JSoC 2019](/blog/2019/05/jsoc19).
-
+Here is a list of all the [Projects for GSoC and JSoC 2019](/blog/2019/05/jsoc19).
 
 ## GSoC 2018
 


### PR DESCRIPTION
Fixed : #1831 Issue

The [Summer of Code Archives](https://julialang.org/jsoc/archive/#summer_of_code_archives) is not updated for GSOC years 2021 and 2022.

I updated it with the best knowledge... If any changes are needed please let me know.

Please consider my pull request and review it. ... happy to Contribute.

Note : The information is collected from the official page of  [GSOC](https://summerofcode.withgoogle.com/) .