### PR TITLE
Update julia-1.9-highlights.md link numbered prompt docs

### DIFF
--- a/blog/2023/04/julia-1.9-highlights.md
+++ b/blog/2023/04/julia-1.9-highlights.md
@@ -226,7 +226,7 @@ Being able to refer to an earlier evaluated object can be useful if, for example
 | :--------: | :--------: |
 | Julia REPL with "numbered prompt" | IPython REPL |
 
-For instructions how to enable this, see the documentation: https://docs.julialang.org/en/v1/stdlib/REPL/#Numbered-prompt.
+For instructions how to enable this, see the documentation: [https://docs.julialang.org/en/v1/stdlib/REPL/#Numbered-prompt](https://docs.julialang.org/en/v1/stdlib/REPL/#Numbered-prompt)
 
 
 ## DelimitedFiles -- first stdlib to be upgradable


### PR DESCRIPTION
https://docs.julialang.org/en/v1/stdlib/REPL/#Numbered-prompt was not a link on the web page. This makes it into a hyperlink.