### PR TITLE
Correct command to activate package environment for testing

### DIFF
--- a/contribute/developing_package.md
+++ b/contribute/developing_package.md
@@ -140,12 +140,12 @@ To run the test defined above:
 1. In your terminal, go to your package directory.
 2. Open the Julia REPL.
 3. Go to the **package mode** by typing `]`.
-4. Activate the package environment by running `activate` command,
+4. Activate the package environment by running `activate .` command,
 5. In the package mode, run the command `test`.
 
 ```
 julia> ] # Go to the package mode
-(v1.8) pkg> activate YourPackageName # Your package name
+(v1.8) pkg> activate .
 (YourPackageName) pkg> test
 ```
 


### PR DESCRIPTION
I was following the guide to develop my first Julia package. During [Step 4: Test your package](https://julialang.org/contribute/developing_package/#step_4_test_your_package), I followed the instruction but testing failed with `ERROR: trying to test unnamed project`. A closer inspection shows that by running 
```julia
(v1.8) pkg> activate YourPackageName # Your package name
```
a new folder named `YourPackageName` is created within my package directory, instead of activating the existing package environment. Changing the command to
```julia
(v1.8) pkg> activate .
```
solves the issue.

One complication is that using `activate .` requires the REPL to be in the package directory, which should already be the case if the user follows the current instruction.