### PR TITLE
Set upcoming release to 1.10.0-alpha1

### DIFF
--- a/config.md
+++ b/config.md
@@ -25,7 +25,7 @@ hasplotly = false
 
 # If the following lines are commented, the "upcoming release" section
 # in `downloads/index.md` will not be shown.
-#upcoming_release = "1.9.0-rc3"
-#upcoming_release_short = "1.9"
-#upcoming_release_date = "April 26, 2023"
+upcoming_release = "1.10.0-alpha1"
+upcoming_release_short = "1.10"
+upcoming_release_date = "July 6, 2023"
 +++

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -237,11 +237,12 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
     </tr>
     <tr>
       <th> Source </th>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz">Tarball</a>
-        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz.asc">GPG</a>)
+      <!-- TODO: Uncomment the source tarballs once building them is fixed -->
+      <td colspan="2"> !<-- <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz">Tarball</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz.asc">GPG</a>) -->
       </td>
-      <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz">Tarball with dependencies</a>
-        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz.asc">GPG</a>)
+      <td colspan="2"> !<-- <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz">Tarball with dependencies</a>
+        (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz.asc">GPG</a>) -->
       </td>
       <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v{{upcoming_release}}">GitHub</a> </td>
     </tr>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -238,10 +238,10 @@ Checksums for this release are available in both, [MD5](https://julialang-s3.jul
     <tr>
       <th> Source </th>
       <!-- TODO: Uncomment the source tarballs once building them is fixed -->
-      <td colspan="2"> !<-- <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz">Tarball</a>
+      <td colspan="2"> <!-- <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz">Tarball</a>
         (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}.tar.gz.asc">GPG</a>) -->
       </td>
-      <td colspan="2"> !<-- <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz">Tarball with dependencies</a>
+      <td colspan="2"> <!-- <a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz">Tarball with dependencies</a>
         (<a href="https://github.com/JuliaLang/julia/releases/download/v{{upcoming_release}}/julia-{{upcoming_release}}-full.tar.gz.asc">GPG</a>) -->
       </td>
       <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v{{upcoming_release}}">GitHub</a> </td>


### PR DESCRIPTION
I had to comment out the links to the source tarballs because the build fails when trying to create them. Since it's an alpha, we can skip them for this release and fix the issue for the next alpha/beta/whatever.