### PR TITLE
Update index.html for JuliaCon videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <div class="alert alert-dark alert-dismissible mb-0" role="alert">
 
       <p class="text-center">
-	      <a href="https://pretalx.com/juliacon2023/schedule/">JuliaCon 2023 is live now! </a> | <a href="https://juliacon.org/2023/tickets/">Buy your JuliaCon tickets now!</a>
+	      Did you miss JuliaCon 2023? <a href="https://www.youtube.com/watch?v=wmCra6roZn4&list=PLP8iPy9hna6T7PRe2sucSonFsrrH-oEZC">Watch the 10th annual JuliaCon talks on YouTube!</a>
       </p>
 
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">


### PR DESCRIPTION
Replace the ticket sales link with a link to the YouTube videos:

Did you miss JuliaCon 2023? <a href="https://www.youtube.com/watch?v=wmCra6roZn4&list=PLP8iPy9hna6T7PRe2sucSonFsrrH-oEZC">Watch the 10th annual JuliaCon talks on YouTube!</a>