### PR TITLE
Change logan@julialang.org to community@julialang.org

### DIFF
--- a/about/help.md
+++ b/about/help.md
@@ -38,4 +38,4 @@
  - Contact `contact@julialang.org` and let us know how we can help!
  
 ## Anything else?
- - Contact `logan@julialang.org` and let us know how we can help!
+ - Contact `community@julialang.org` and let us know how we can help!

--- a/community/index.md
+++ b/community/index.md
@@ -109,7 +109,7 @@ From: https://stackoverflow.com/questions/31821974/support-user-time-zone-in-emb
      </div>
 
      <br>
-     <p>The Julia Community has a shared calendar for all upcoming global events. If you are an event organizer, please <a href="mailto:logan@julialang.org">email us</a>
+     <p>The Julia Community has a shared calendar for all upcoming global events. If you are an event organizer, please <a href="mailto:community@julialang.org">email us</a>
      with the details so it can be added to the calendar. The Julia community also has <a href="https://www.meetup.com/topics/julia/all/">local meetups around the world.</a></p>
       <div id="calendar-container">
            <iframe src="https://calendar.google.com/calendar/b/2/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=UTC&amp;src=anVsaWFsYW5nLm9yZ19rb21hdWFxZXQxNGVvZzlvaXYzcDZvN3BtZ0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%238E24AA" style="border:solid 1px #777" width="100%" height="600" frameborder="0" scrolling="no"></iframe>

--- a/jsoc/gsod/projects.md
+++ b/jsoc/gsod/projects.md
@@ -1,6 +1,6 @@
 # Julia's Google Season of Docs Projects
 
-Below are the projects which have been proposed for Google Season of Docs under the umbrella of the Julia Language. If you have questions about potential projects, the first point of contact would be the mentor(s) listed on the project. If you are unable to get ahold of the potential mentor(s), you should email `jsoc@julialang.org` and CC `logan@julialang.org`.
+Below are the projects which have been proposed for Google Season of Docs under the umbrella of the Julia Language. If you have questions about potential projects, the first point of contact would be the mentor(s) listed on the project. If you are unable to get ahold of the potential mentor(s), you should email `jsoc@julialang.org` and CC `community@julialang.org`.
 
 We at the Julia Language are committed to making the application process and participation in GSoD with Julia accessible to everyone. If you have questions or requests, please do reach out and we will do our best to accommodate you.
 

--- a/jsoc/guidelines.md
+++ b/jsoc/guidelines.md
@@ -12,7 +12,7 @@ progress on your project early on. While PRs before the applications are not
 required, the Julia Language organization programs are extremely competitive,
 so the more ways you have to show your commitment, the better.
 
-_If you have accessibility needs with respect to submitting your application, please email `logan@julialang.org` to get further assistance with your application. We are committed to making this application process accommodating for everyone._
+_If you have accessibility needs with respect to submitting your application, please email `community@julialang.org` to get further assistance with your application. We are committed to making this application process accommodating for everyone._
 
 ~~~
 <iframe width="100%" height="400" src="https://www.youtube-nocookie.com/embed/YN7uGCg5vLg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/learning/index.md
+++ b/learning/index.md
@@ -133,7 +133,7 @@
      See <a href="classes/">where Julia is being taught today</a>.
      </p>
      <img src="assets/schools.png" alt="Collection of schools where Julia is taught" class="img-fluid">
-     <!-- You can find the editable classroom image here: https://docs.google.com/presentation/d/1t94qHV-Al8gr-AVGEB4RG1KPYMZEN0CUdlfV2oPsAgU/edit?usp=sharing Please ping logan@julialang.org for access.  -->
+     <!-- You can find the editable classroom image here: https://docs.google.com/presentation/d/1t94qHV-Al8gr-AVGEB4RG1KPYMZEN0CUdlfV2oPsAgU/edit?usp=sharing Please ping community@julialang.org for access.  -->
    </div>
  </div>
 <br>


### PR DESCRIPTION
Logan Kilpatrick stepped down as community manager effective September 8, 2023.

https://discourse.julialang.org/t/goodbye-and-thank-you-for-now/103668
