### PR TITLE
Update `greet_your_package_name` in developing_package.md to make tests pass 

### DIFF
--- a/contribute/developing_package.md
+++ b/contribute/developing_package.md
@@ -91,7 +91,7 @@ To include a function from a different file in `YourPackageName.jl`:
 
 ```
 function greet_your_package_name()
-    println("Hello YourPackageName!")
+    return "Hello YourPackageName!"
 end
 ```
 3. Export the function `greet_your_package_name()` so that is available to users as follows:


### PR DESCRIPTION
When `greet_your_package_name()` is defined, the `println("Hello YourPackageName!")` creates an object of type `::Nothing`. So the testset created later on never passes, because it is comparing an object of `::String` to one of `::Nothing` 