### PR TITLE
Move protective comment closer to the content it refers to [nfc]

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -8,10 +8,6 @@ Please star us [on GitHub](https://github.com/JuliaLang/julia). If you use Julia
 
 ---
 
-<!--
-IF YOU'RE THINKING ABOUT REMOVING THIS NOTE, DON'T. ACCORDING TO OUR LAWYERS, THIS NEEDS TO BE HERE TO COMPLY WITH THE GDPR. YES, IT'S STUPID. I DON'T MAKE THE RULES.
--->
-
 ~~~
 <h2 id=current_stable_release><a href="#current_stable_release">Current stable release: v{{stable_release}} ({{stable_release_date}})</a></h2>
 ~~~
@@ -400,5 +396,9 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
 The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json) ([schema](https://julialang-s3.julialang.org/bin/versions-schema.json)). It may take up to two hours after the release of a new version for it to be included in the JSON file.
 
 ---
+
+<!--
+IF YOU'RE THINKING ABOUT REMOVING THIS NOTE, DON'T. ACCORDING TO OUR LAWYERS, THIS NEEDS TO BE HERE TO COMPLY WITH THE GDPR. YES, IT'S STUPID. I DON'T MAKE THE RULES.
+-->
 
 **Note:** Julia comes with a built-in package manager which downloads and installs packages from the Internet. In doing so, it necessarily reveals your public [IP address](https://en.wikipedia.org/wiki/IP_address) to any server you connect to, and service providers may log your IP address. In Julia versions 1.5 and higher, by default the package manager connects to <https://pkg.julialang.org>, a free public service operated by the Julia project to serve open source package resources to Julia users. This service retains IP address logs for up to 31 days.


### PR DESCRIPTION
This disclaimer was moved to the top and comment added in #1432 cc @StefanKarpinski 
And then the note was moved to the bottom without the comment in #1456 cc @ViralBShah 

The disclaimer and comment should be together. If it's unlawful to have the note at the bottom, then the comment should say so. I'm not a lawyer this isn't legal advice.