### PR TITLE
Qualify sweeping claim about the Julia Forem

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -79,7 +79,7 @@ From: https://stackoverflow.com/questions/31821974/support-user-time-zone-in-emb
      <!-- 6 -->
      <div class="col-lg-4 col-md-6 feature">
        <h3>Forem</h3>
-       <p>The Julia Forem is the best place for the community to read, write, and share written content. Join the Forem today and start writing <a href="https://forem.julialang.org">https://forem.julialang.org</a>.
+       <p>The Julia Forem is the best place for the community to read, write, and share long form written content. Join the Forem today and start writing <a href="https://forem.julialang.org">https://forem.julialang.org</a>.
        </p>
      </div>
    </div>


### PR DESCRIPTION
"the best place for the community to read, write, and share written content." is an incredibly strong claim. Too strong, IMO.

I've qualified it to refer to long form content as Zulip may be better for informal short form written content and Discourse may be better for short and medium length written content (if only due to higher user base).

As an alternative, we could weaken it to "a good place for the community to read, write, and share written content."