### PR TITLE
fix download page title

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -1,4 +1,6 @@
 
+@def title = "Download Julia"
+
 ~~~
   <div class="main-download-instructions">
    <div class="main-download-instructions-inner">


### PR DESCRIPTION
Because the first header is inserted manually we have to set the title