### PR TITLE
Update deploy.yml to remove problematic minifier step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
               using NodeJS; run(`$(npm_cmd()) install highlight.js`);
               using Franklin;
               Franklin.HIGHLIGHTJS[] = abspath(joinpath("_libs", "highlight", "highlight.min.js"));
-              Franklin.optimize(prerender=true);
+              Franklin.optimize(prerender=true, minify=false);
               cp(joinpath("__site", "feed.xml"), joinpath("__site", "index.xml"))' > build.log
           cat build.log
 


### PR DESCRIPTION
The minifier that Franklin leans on is buggy and, in any case, github pages optimises stuff for us so it's not needed.

In the context of #2006, it will help to disable it to see the generated HTML more clearly.


impact can be assessed here: https://github.com/JuliaLang/www.julialang.org/tree/gh-preview/previews/PR2013 where everything is generated properly and e.g. the `index.html` is not garbled anymore (and does actually have a closing html tag) https://github.com/JuliaLang/www.julialang.org/blob/gh-preview/previews/PR2013/index.html

