### PR TITLE
Taija.jl project proposals for GSoC

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,18 +1,31 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
 [[Artifacts]]
-deps = ["Pkg"]
-git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[Crayons]]
-git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
-uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-version = "4.0.4"
+[[BitFlags]]
+git-tree-sha1 = "2dc09997850d68179b69dafb58ae806167a32b1b"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.8"
+
+[[CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "59939d8a997469ee05c4b4944560a820f9ba0d73"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.4"
+
+[[ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "9c4708e3ed2b799e6124b5673a712dda0b596a9b"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.3.1"
 
 [[Dates]]
 deps = ["Printf"]
@@ -20,156 +33,254 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[DelimitedFiles]]
 deps = ["Mmap"]
+git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.9.1"
 
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+deps = ["LibGit2"]
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.3"
+version = "0.9.3"
+
+[[Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "dcb08a0d93ec0b1cdc4af184b26b591e9695423a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.10"
 
 [[ExprTools]]
-git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
+git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-version = "0.1.3"
+version = "0.1.10"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[Franklin]]
-deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "ExprTools", "FranklinTemplates", "HTTP", "Literate", "LiveServer", "Logging", "Markdown", "NodeJS", "OrderedCollections", "Pkg", "REPL", "Random"]
-git-tree-sha1 = "f92852d1d22d9d5f36f1ef11647718153bcfd895"
+deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "ExprTools", "FranklinTemplates", "HTTP", "Literate", "LiveServer", "Logging", "Markdown", "NodeJS", "OrderedCollections", "Pkg", "REPL", "Random", "TOML"]
+git-tree-sha1 = "31e70717e0640d6576fe04d611a33df1c9c312d6"
 uuid = "713c75ef-9fc9-4b05-94a9-213340da978e"
-version = "0.10.28"
+version = "0.10.95"
 
 [[FranklinTemplates]]
 deps = ["LiveServer"]
-git-tree-sha1 = "7159314a91990842cfa6484f3a0fd5666015a7c2"
+git-tree-sha1 = "c01813a615149ddb3b3d133f33de29d642fbe57b"
 uuid = "3a985190-f512-4703-8d38-2a7944ed5916"
-version = "0.8.12"
+version = "0.10.2"
 
 [[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets", "URIs"]
-git-tree-sha1 = "63055ee44b5c2b95ec1921edcf856c60124ff0c3"
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "ac7b73d562b8f4287c3b67b4c66a5395a19c1ae8"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.2"
+version = "1.10.2"
 
-[[IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
+[[IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "8b72179abc660bfab5e28472e019392b97d0985c"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.4"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLLWrappers]]
-git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.2.0"
+version = "1.5.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.4"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.4.0+0"
 
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Literate]]
-deps = ["Base64", "JSON", "REPL"]
-git-tree-sha1 = "32b517d4d8219d3bbab199de3416ace45010bdb3"
+deps = ["Base64", "IOCapture", "JSON", "REPL"]
+git-tree-sha1 = "bad26f1ccd99c553886ec0725e99a509589dcd11"
 uuid = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-version = "2.8.0"
+version = "2.16.1"
 
 [[LiveServer]]
-deps = ["Crayons", "FileWatching", "HTTP", "Pkg", "Sockets", "Test"]
-git-tree-sha1 = "7c2f32edab7941184a58ef56d589dac14e0ffa23"
+deps = ["HTTP", "LoggingExtras", "MIMEs", "Pkg", "Sockets", "Test"]
+git-tree-sha1 = "24d05efe53436b22a42bf2ae459f47c48b0c2603"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
-version = "0.6.0"
+version = "1.2.7"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "c1dd6d7978c12545b4179fb6153b9250c96b0075"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.0.3"
+
+[[MIMEs]]
+git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
+uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
+version = "0.1.4"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "c067a280ddc25f196b5e7df3877c6b226d390aaf"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
+version = "1.1.9"
 
 [[MbedTLS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
+deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+1"
+version = "2.28.2+1"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.1.10"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
 [[NodeJS]]
 deps = ["Pkg"]
-git-tree-sha1 = "350ac618f41958e6e0f6b0d2005ae4547eb1b503"
+git-tree-sha1 = "bf1f49fd62754064bc42490a8ddc2aa3694a8e7a"
 uuid = "2bd173c7-0d6d-553b-b6af-13a54713934c"
-version = "1.1.1"
+version = "2.0.0"
+
+[[OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "51901a49222b09e3743c65b8847687ae5fc78eb2"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.4.1"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "60e3045590bd104a16fefb12836c00c0ef8c7f8c"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.0.13+0"
 
 [[OrderedCollections]]
-git-tree-sha1 = "d45739abcfc03b51f6a42712894a593f74c80a23"
+git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.3"
+version = "1.6.3"
 
 [[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.15"
+version = "2.8.1"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.10.0"
+
+[[PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.1"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SimpleBufferStream]]
+git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.1.0"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[TranscodingStreams]]
+git-tree-sha1 = "54194d92959d8ebaa8e26227dbe3cdefcdcd594f"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.10.3"
+weakdeps = ["Random", "Test"]
+
+    [TranscodingStreams.extensions]
+    TestExt = ["Test", "Random"]
+
 [[URIs]]
-git-tree-sha1 = "7855809b88d7b16e9b029afd17880930626f54a2"
+git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.2.0"
+version = "1.5.1"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -177,3 +288,18 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.52.0+1"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/jsoc/gsoc/taija.md
+++ b/jsoc/gsoc/taija.md
@@ -20,9 +20,7 @@ There is a high overlap with organizations, you might be also interested in:
 - [Projects with MLJ.jl](https://julialang.org/jsoc/gsoc/MLJ/) - For more traditional machine learning projects
 - [Projects with FluxML](https://fluxml.ai/gsoc/) - For projects around Flux.jl, the backbone of Julia's deep learning ecosystem
 
-## Model Explainability Projects
-
-### Project 1: Enhancing llama2.jl with GPU Support
+## Project 1: Counterfactual Regression (*Model Explainability*)
 
 **Project Overview:** [Llama2.jl](https://github.com/cafaxo/Llama2.jl) is a Julia native port for Llama architectures, originally based on [llama2.c](https://github.com/karpathy/llama2.c). This project aims to enhance Llama2.jl by implementing GPU support through KernelAbstraction.jl, significantly improving its performance.
 
@@ -42,7 +40,9 @@ There is a high overlap with organizations, you might be also interested in:
 - Comprehensive documentation and examples demonstrating the performance improvements
 - Contribution to llama2.jl's existing codebase and documentation
 
-## Predictive Uncertainty Projects
+## Project 2: Conformal Prediction Meets Bayes (*Predictive Uncertainty*)
+
+
 
 ## Hybrid Modelling Projects
 

--- a/jsoc/gsoc/taija.md
+++ b/jsoc/gsoc/taija.md
@@ -24,7 +24,7 @@ There is a high overlap with organizations, you might be also interested in:
 
 **Project Overview:** [Llama2.jl](https://github.com/cafaxo/Llama2.jl) is a Julia native port for Llama architectures, originally based on [llama2.c](https://github.com/karpathy/llama2.c). This project aims to enhance Llama2.jl by implementing GPU support through KernelAbstraction.jl, significantly improving its performance.
 
-**Mentor:** [Cameron Pfiffer](https://github.com/cpfiffer)
+**Mentor:** [Patrick Altmeyer](https://github.com/pat-alt)
 
 **Project Difficulty**: Hard
 
@@ -40,11 +40,25 @@ There is a high overlap with organizations, you might be also interested in:
 - Comprehensive documentation and examples demonstrating the performance improvements
 - Contribution to llama2.jl's existing codebase and documentation
 
-## Project 2: Conformal Prediction Meets Bayes (*Predictive Uncertainty*)
+## Project 2: Enhancing Conformal Prediction with Conformal Training, Bayes and Additional Methods (*Predictive Uncertainty*)
 
+**Project Overview:** [Llama2.jl](https://github.com/cafaxo/Llama2.jl) is a Julia native port for Llama architectures, originally based on [llama2.c](https://github.com/karpathy/llama2.c). This project aims to enhance Llama2.jl by implementing GPU support through KernelAbstraction.jl, significantly improving its performance.
 
+**Mentor:** [Patrick Altmeyer](https://github.com/pat-alt)
 
-## Hybrid Modelling Projects
+**Project Difficulty**: Hard
+
+**Estimated Duration**: 350 hours
+
+**Ideal Candidate Profile:**
+- Proficiency in Julia programming
+- Understanding of GPU computing
+- Experience with KernelAbstractions.jl
+
+**Project Goals and Deliverables:**
+- Implementation of GPU support in llama2.jl
+- Comprehensive documentation and examples demonstrating the performance improvements
+- Contribution to llama2.jl's existing codebase and documentation
 
 ## How to Contact Us
 

--- a/jsoc/gsoc/taija.md
+++ b/jsoc/gsoc/taija.md
@@ -20,9 +20,30 @@ There is a high overlap with organizations, you might be also interested in:
 - [Projects with MLJ.jl](https://julialang.org/jsoc/gsoc/MLJ/) - For more traditional machine learning projects
 - [Projects with FluxML](https://fluxml.ai/gsoc/) - For projects around Flux.jl, the backbone of Julia's deep learning ecosystem
 
-## Project 1: Counterfactual Regression (*Model Explainability*)
+## Project 1: Conformal Prediction meets Bayes (*Predictive Uncertainty*)
 
-**Project Overview:** [Llama2.jl](https://github.com/cafaxo/Llama2.jl) is a Julia native port for Llama architectures, originally based on [llama2.c](https://github.com/karpathy/llama2.c). This project aims to enhance Llama2.jl by implementing GPU support through KernelAbstraction.jl, significantly improving its performance.
+**Project Overview:** [ConformalPrediction.jl](https://github.com/JuliaTrustworthyAI/ConformalPrediction.jl) is a package for Predictive Uncertainty Quantification through Conformal Prediction for Machine Learning models trained in MLJ. This project aims to enhance ConformalPrediction.jl by adding support for [Conformal(ized) Bayes](https://github.com/JuliaTrustworthyAI/ConformalPrediction.jl/issues/64). 
+
+**Mentor:** [Patrick Altmeyer](https://github.com/pat-alt)
+
+**Project Difficulty**: Medium
+
+**Estimated Duration**: 175 hours
+
+**Ideal Candidate Profile:**
+- Basic knowledge of Julia or strong knowledge of similar programming languages (R, Python, MATLAB, ...)
+- Good understanding of Bayesian methods
+- Basic knowledge of Conformal Prediction
+
+**Project Goals and Deliverables:**
+- Implement support for conformalizing predictive distributions ([#109](https://github.com/JuliaTrustworthyAI/ConformalPrediction.jl/issues/109))
+- Implement support for Conformal Bayes through Add-One-In Importance Sampling ([#110](https://github.com/JuliaTrustworthyAI/ConformalPrediction.jl/issues/110))
+- Implement other recent approaches combining Bayes with Conformal Prediction that you find interesting
+- Comprehensively test and document your work
+
+## Project 2: Counterfactual Regression (*Model Explainability*)
+
+**Project Overview:** [CounterfactualExplanations.jl](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl) is a package for Counterfactual Explanations and Algorithmic Recourse in Julia. This project aims to extend the package functionality to [regression models](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl/issues/388). 
 
 **Mentor:** [Patrick Altmeyer](https://github.com/pat-alt)
 
@@ -31,34 +52,18 @@ There is a high overlap with organizations, you might be also interested in:
 **Estimated Duration**: 350 hours
 
 **Ideal Candidate Profile:**
-- Proficiency in Julia programming
-- Understanding of GPU computing
-- Experience with KernelAbstractions.jl
+- Experience with Julia and multiple dispatch of advantage, but not crucial
+- Good knowledge of machine learning and statistics
+- Solid understanding of supervised models (classification and regression)
 
 **Project Goals and Deliverables:**
-- Implementation of GPU support in llama2.jl
-- Comprehensive documentation and examples demonstrating the performance improvements
-- Contribution to llama2.jl's existing codebase and documentation
+- Carefully think about architecture choices: how can we fit support for regression models into the existing code base?
+- Add support for the following approaches: [ad-hoc thresholding](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl/issues/391), [Bayesian optimisation](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl/issues/392), [information-theoretic saliency](https://openreview.net/forum?id=IrEYkhuxup&noteId=IrEYkhuxup).
+- Comprehensively test and document your work
 
-## Project 2: Enhancing Conformal Prediction with Conformal Training, Bayes and Additional Methods (*Predictive Uncertainty*)
+## About Us
 
-**Project Overview:** [Llama2.jl](https://github.com/cafaxo/Llama2.jl) is a Julia native port for Llama architectures, originally based on [llama2.c](https://github.com/karpathy/llama2.c). This project aims to enhance Llama2.jl by implementing GPU support through KernelAbstraction.jl, significantly improving its performance.
-
-**Mentor:** [Patrick Altmeyer](https://github.com/pat-alt)
-
-**Project Difficulty**: Hard
-
-**Estimated Duration**: 350 hours
-
-**Ideal Candidate Profile:**
-- Proficiency in Julia programming
-- Understanding of GPU computing
-- Experience with KernelAbstractions.jl
-
-**Project Goals and Deliverables:**
-- Implementation of GPU support in llama2.jl
-- Comprehensive documentation and examples demonstrating the performance improvements
-- Contribution to llama2.jl's existing codebase and documentation
+[Patrick Altmeyer](https://www.paltmeyer.com/) is a PhD Candidate in Trustworthy Artificial Intelligence at Delft University of Technology working on the intersection of Computer Science and Finance. He has presented work related to Taija at JuliaCon 2022 and 2023. In the past year, Patrick has mentored multiple groups of students at Delft University of Technology who have made major contributions to Taija. 
 
 ## How to Contact Us
 

--- a/jsoc/gsoc/taija.md
+++ b/jsoc/gsoc/taija.md
@@ -1,0 +1,54 @@
+# Taija Projects
+
+![Taija Logo](https://raw.githubusercontent.com/TrustworthyAIJulia/.github/main/profile/www/wide_logo.png)
+
+[Taija](https://github.com/JuliaTrustworthyAI) is an organization organization that hosts software geared towards Trustworthy Artificial Intelligence in Julia. Taija currently covers a range of approaches towards making AI systems more trustworthy:
+
+- Model Explainability ([CounterfactualExplanations.jl](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl))
+- Algorithmic Recourse ([CounterfactualExplanations.jl](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl), [AlgorithmicRecourseDynamics.jl](https://github.com/JuliaTrustworthyAI/AlgorithmicRecourseDynamics.jl))
+- Predictive Uncertainty Quantification ([ConformalPrediction.jl](https://github.com/JuliaTrustworthyAI/ConformalPrediction.jl), [LaplaceRedux.jl](https://github.com/JuliaTrustworthyAI/LaplaceRedux.jl))
+- Effortless Bayesian Deep Learning ([LaplaceRedux.jl](https://github.com/JuliaTrustworthyAI/LaplaceRedux.jl))
+- Hybrid Learning ([JointEnergyModels.jl](https://github.com/JuliaTrustworthyAI/JointEnergyModels.jl))
+
+Various meta packages can be used to extend the core functionality:
+
+- Plotting ([TaijaPlotting.jl](https://github.com/JuliaTrustworthyAI/TaijaPlotting.jl))
+- Datasets for testing and benchmarking ([TaijaData.jl](https://github.com/JuliaTrustworthyAI/TaijaData.jl))
+- Interoperability with other programming languages ([TaijaInteroperability.jl](https://github.com/JuliaTrustworthyAI/TaijaInteroperability.jl))
+
+There is a high overlap with organizations, you might be also interested in:
+- [Projects with MLJ.jl](https://julialang.org/jsoc/gsoc/MLJ/) - For more traditional machine learning projects
+- [Projects with FluxML](https://fluxml.ai/gsoc/) - For projects around Flux.jl, the backbone of Julia's deep learning ecosystem
+
+## Model Explainability Projects
+
+### Project 1: Enhancing llama2.jl with GPU Support
+
+**Project Overview:** [Llama2.jl](https://github.com/cafaxo/Llama2.jl) is a Julia native port for Llama architectures, originally based on [llama2.c](https://github.com/karpathy/llama2.c). This project aims to enhance Llama2.jl by implementing GPU support through KernelAbstraction.jl, significantly improving its performance.
+
+**Mentor:** [Cameron Pfiffer](https://github.com/cpfiffer)
+
+**Project Difficulty**: Hard
+
+**Estimated Duration**: 350 hours
+
+**Ideal Candidate Profile:**
+- Proficiency in Julia programming
+- Understanding of GPU computing
+- Experience with KernelAbstractions.jl
+
+**Project Goals and Deliverables:**
+- Implementation of GPU support in llama2.jl
+- Comprehensive documentation and examples demonstrating the performance improvements
+- Contribution to llama2.jl's existing codebase and documentation
+
+## Predictive Uncertainty Projects
+
+## Hybrid Modelling Projects
+
+## How to Contact Us
+
+We'd love to hear your ideas and discuss potential projects with you.
+
+Probably the easiest way is to join our [JuliaLang Slack](https://julialang.org/slack/) and join the `#taija` channel. You can also post a GitHub Issue on our organization [repo](https://github.com/JuliaTrustworthyAI/.github/issues).
+

--- a/jsoc/gsoc/taija.md
+++ b/jsoc/gsoc/taija.md
@@ -1,7 +1,5 @@
 # Taija Projects
 
-![Taija Logo](https://raw.githubusercontent.com/TrustworthyAIJulia/.github/main/profile/www/wide_logo.png)
-
 [Taija](https://github.com/JuliaTrustworthyAI) is an organization organization that hosts software geared towards Trustworthy Artificial Intelligence in Julia. Taija currently covers a range of approaches towards making AI systems more trustworthy:
 
 - Model Explainability ([CounterfactualExplanations.jl](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl))
@@ -70,4 +68,6 @@ There is a high overlap with organizations, you might be also interested in:
 We'd love to hear your ideas and discuss potential projects with you.
 
 Probably the easiest way is to join our [JuliaLang Slack](https://julialang.org/slack/) and join the `#taija` channel. You can also post a GitHub Issue on our organization [repo](https://github.com/JuliaTrustworthyAI/.github/issues).
+
+[![Taija Logo](https://raw.githubusercontent.com/TrustworthyAIJulia/.github/main/profile/www/wide_logo.png)](https://github.com/JuliaTrustworthyAI)
 

--- a/jsoc/gsod/projects.md
+++ b/jsoc/gsod/projects.md
@@ -20,3 +20,13 @@ Below you can find a running list of potential GSoD projects. If any of these ar
 Today, there is no clear option for R users to make the transition to Julia. [Tidier.jl](https://github.com/kdpsingh/Tidier.jl) is working to solve this problem by building the entire tidyverse ecosystem from the ground up in Julia. The tidyverse is one of the main reasons developers stick with the R programming language, despite the many benefits of a modern programming language like Julia. We plan to leverage Tidier.jl to usher in the next 1 million Julia users. 
 
 Mentor: [Karandeep Singh](https://github.com/kdpsingh)
+
+# Project Ideas for 2024
+
+Below you can find a running list of potential GSoD projects. If any of these are of interest to you, please reachout to the respective mentor(s).
+
+## Unify and Enhance Taija.jl Usage Guides and Core Documentation
+
+
+
+Mentor: [Patrick Altmeyer](https://github.com/kdpsingh)

--- a/jsoc/gsod/projects.md
+++ b/jsoc/gsod/projects.md
@@ -23,10 +23,10 @@ Mentor: [Karandeep Singh](https://github.com/kdpsingh)
 
 # Project Ideas for 2024
 
-Below you can find a running list of potential GSoD projects. If any of these are of interest to you, please reachout to the respective mentor(s).
+Below you can find a running list of potential GSoD projects. If any of these are of interest to you, please reach out to the respective mentor(s).
 
 ## Unify and Enhance Taija.jl Usage Guides and Core Documentation
 
-
+[Taija](https://github.com/JuliaTrustworthyAI) is an organization that hosts software geared towards Trustworthy Artificial Intelligence in Julia. Currently, documentation is hosted separately for each package. The goal of this project is to unify and enhance the existing documentation following the example of [SciML](https://docs.sciml.ai/Overview/stable/). We also plan to fully automate documentation workflows by leveraging the interplay between Documenter.jl and Quarto (see [here](https://forem.julialang.org/kellertuer/render-quarto-tutorials-in-documenterjl-with-github-actions-3fo)). If you are interested in Trustworthy AI, Julia, open science and technical writing, then this project is ideal for you. 
 
 Mentor: [Patrick Altmeyer](https://github.com/kdpsingh)

--- a/jsoc/projects.md
+++ b/jsoc/projects.md
@@ -30,6 +30,7 @@ We have our project ideas organized below roughly by domain but you can also see
 * [Signal processing](/jsoc/gsoc/kalmanbucy/) - Continuous time Signal Processing
 * [Symbolic computation](/jsoc/gsoc/symbolics/) - User friendly symbolic programming
 * [Tabular Data](/jsoc/gsoc/tables/) - Working with data
+* [Taija](/jsoc/gsoc/taija/) - Trustworthy Artificial Intelligence in Julia
 * [Turing](/jsoc/gsoc/turing/) - for probabilistic modelling and probabilistic programming
 * [Topology optimisation](/jsoc/gsoc/topopt/) - improving topology optimisation tools in Julia.
 * [Trixi.jl](/jsoc/gsoc/trixi/) - modern computational fluid dynamics with Trixi.jl in Julia.


### PR DESCRIPTION
This PR 

1. Adds two project proposals for GSoC for [Taija.jl](https://github.com/JuliaTrustworthyAI). 
2. Adds a project proposal for JSoD for Taija.jl. (*I have left the existing proposal by @kdpsingh for 2023 in there for now. Should I remove that?*)
3. Updates the Manifest.toml (following local `serve()` of the website).