### PR TITLE
Remove Documenter JSOC project

### DIFF
--- a/jsoc/gsoc/documenter.md
+++ b/jsoc/gsoc/documenter.md
@@ -3,9 +3,3 @@
 ## Documenter.jl
 
 The Julia manual and the documentation for a large chunk of the ecosystem is generated using [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) -- essentially a static site generator that integrates with Julia and its docsystem. There are tons of opportunities for improvements for anyone interested in working on the interface of Julia, documentation and various front-end technologies (web, LaTeX).
-
-* **ElasticSearch-based search backend for Documenter.** (350 hours) Loading the search page of Julia manual is slow because the index is huge and needs to be downloaded and constructed on the client side on every page load (currently implemented with [lunr.js](https://lunrjs.com/)). Instead, we should look at hosting the search server-side. The goal is to implement an [ElasticSearch](https://www.elastic.co/)-based search backend for Documenter.
-
-**Recommended skills:** Basic knowledge of web-development (JS, CSS, HTML).
-
-**Mentors:** [Morten Piibeleht](https://github.com/mortenpi)

--- a/jsoc/projects.md
+++ b/jsoc/projects.md
@@ -7,7 +7,7 @@ We have our project ideas organized below roughly by domain but you can also see
 @@tight-list
 * [BayesianOptimization.jl](/jsoc/gsoc/bayesopt/) - a package for global optimization of black-box functions
 * [Compiler](/jsoc/gsoc/compiler/) – work on the Julia compiler's internals to make things better for everyone.
-* [Documentation tooling](/jsoc/gsoc/documenter/) - Tooling related to documentation generation, docstrings etc.
+<!--* [Documentation tooling](/jsoc/gsoc/documenter/) - Tooling related to documentation generation, docstrings etc.-->
 * [Ferrite FEM](/jsoc/gsoc/ferrite-fem/) - A modern finite element toolbox in Julia.
 * [Loop Optimization](/jsoc/gsoc/loopopt/) - Loop analysis and optimization
 * [Graph neural networks](/jsoc/gsoc/gnn/) - Deep learning on graphs with GraphNeuralNetworks.jl.


### PR DESCRIPTION
The ElasticSearch one is very outdated and confusing. I don't immediately have anything in mind to replace it with, so I'm just hiding the section for now.