### PR TITLE
Bump minimum mac os version to 10.14

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -73,7 +73,7 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
     </tr>
     <tr>
       <td rowspan="3"> macOS </td>
-      <td> 10.10+ </td>
+      <td> 10.14+ </td>
       <td> x86-64 (64-bit) </td>
       <td> <font color="green">Tier 1</font> </td>
     </tr>
@@ -83,8 +83,8 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
       <td> <font color="green">Tier 1</font> </td>
     </tr>
     <tr>
-      <td> 10.6+ </td>
-      <td> i686 (32-bit) / x86-64 (64-bit) </td>
+      <td> 10.14+ </td>
+      <td> i686 (32-bit) </td>
       <td> <font color="crimson">Tier 3</font> </td>
     </tr>
     <tr>


### PR DESCRIPTION
As far as I can tell we build LLVM >= 15 with Mac os SDK 10.14 on BinaryBuilder. So I presume that means Julia wouldn’t build on earlier versions and the distributed binaries are incompatible.
Looks like we already updated this on the Julia repo, https://github.com/JuliaLang/julia/blob/715c476d6ac1ccd9f3e7313fa4fad8ce7f5daf0f/Make.inc#L489.