### PR TITLE
Move "Sponsors" into a separate top-level page

### DIFF
--- a/community/sponsors.md
+++ b/community/sponsors.md
@@ -1,0 +1,43 @@
+## Sponsors
+
+# Infrastructure
+
+As a project, Julia encompasses more than just a repository on GitHub.
+Providing a seamless user experience to the Julia community requires a
+significant amount of infrastructure. Runninng this infrastructure is not
+cheap and we are grateful to these organizations for providing compute
+credits, services, hardware and other support essential for keeping Julia
+running:
+
+- [AWS](https://aws.amazon.com) provides a subsantial amount of free compute credits every year that powers major parts of our CI and package management infrastructure.
+- [Fastly](https://www.fastly.com/) provides the Julia project with free CDN services
+- [MacStatdium](https://www.macstadium.com/) is hosting a free M1 Mac mini for CI
+- [ARM](https://www.arm.com/markets/computing-infrastructure/works-on-arm)/[Equinix](https://deploy.equinix.com/) are providing free access to Aarch64 machines for CI
+- [IBM](www.ibm.com) and [OSU OSL](https://osuosl.org/) are providing free access to IBM POWER systems for CI
+- [Microsoft Azure](https://azure.microsoft.com/) is providing free credits improving package server latency to Microsoft Azure customer, most notable GitHub Actions
+- [JuliaHub](https://juliahub.com/) is maintaining data center space for the project and providing a significant number of CI machines
+- [MIT's Julia Lab](https://julia.mit.edu/) is maintaining data center for the project space and providing a significant number of CI machines
+- [NVIDIA](nvidia.com) has provided both JuliaHub and the Julia Lab with a significant number of free GPUs across various generations of NVIDIA products
+
+# Direct Funding
+
+A number of organizations and funding agencies are or have provided direct funding for Julia maintenance.
+
+## Current funding
+
+- [NASA](nasa.gov) is funding efforts towards the creation of high quality released under award number 80NSSC22K1740. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Aeronautics and Space Administration.
+
+- Over the years, [Intel](intel.com) has provided significant funding continuing to support a small development contract for maintenance of Julia on Intel platforms and accelerators.
+
+- Julia receives individual donations from a larger number of individuals through [GitHub sponsors](https://github.com/sponsors/JuliaLang) and [NumFocus](https://numfocus.org/project/julia)
+
+In addition, there are a large number of organizations funding research primarily conducted in Julia or funding
+the specific development of certain Julia features. Funding agencies for these efforts include [NSF](https://nsf.gov), [DARPA](https://www.darpa.mil/), [NIH](https://www.nih.gov/), and the [FAA](https://www.faa.gov/). However, they are not listed here, as this list only includes such funding directly dedicated to ongoing Julia maintenance.
+
+## Past funding
+
+The following organizations have previously directly funded Julia development and maintenance:
+
+* [Lincoln Laboratory](https://www.ll.mit.edu): [Dr. Jeremy Kepner](https://www.mit.edu/~kepner/) is the founding sponsor of the Julia project.
+* [Gordon and Betty Moore Foundation](https://www.moore.org/article-detail?newsUrlName=bringing-julia-from-beta-to-1.0-to-support-data-intensive-scientific-computing)
+* [Alfred P. Sloan Foundation](https://sloan.org/grant-detail/7999)

--- a/research/index.md
+++ b/research/index.md
@@ -29,19 +29,6 @@ Researchers contributing to Julia have been awarded various prizes:
 * [2015: IEEE-CS Charles Babbage Award](https://www.computer.org/web/awards/charles-babbage): Alan Edelman
 @@
 
-## Sponsors
-
-We thank our sponsors for making Julia possible:
-
-@@tight-list
-* [Lincoln Laboratory](https://www.ll.mit.edu): [Dr. Jeremy Kepner](https://www.mit.edu/~kepner/) is the founding sponsor of the Julia project.
-* [Gordon and Betty Moore Foundation](https://www.moore.org/article-detail?newsUrlName=bringing-julia-from-beta-to-1.0-to-support-data-intensive-scientific-computing)
-* [Alfred P. Sloan Foundation](https://sloan.org/grant-detail/7999)
-* Intel
-* Research grants from various agencies have led to Julia contributions: [NSF](https://nsf.gov), [DARPA](https://www.darpa.mil/), [NIH](https://www.nih.gov/), [NASA](https://nasa.gov), and [FAA](https://www.faa.gov/).
-* And all of our [individual sponsors on GitHub](https://github.com/sponsors/JuliaLang).
-@@
-
 ## Publications
 
 Google Scholar provides a list of papers [citing Julia](https://scholar.google.com/scholar?cites=12373977815425691465&as_sdt=40000005&sciodt=0,22&hl=en). A contributed list of citations used to be maintained, which is now [archived](publications-archive).


### PR DESCRIPTION
There are a large number of companies providing some sort of support to Julia. The individual employees at these companies that made these decisions often want to have something to link to demonstrate to their mgmt chain that their contributions are being acknowledged, so move the "Sponsors" section out from research and expand it out to cover the current list.

This is currently not linked from anywhere, but let's agree on the content and then we can figure out where to link it.