### PR TITLE
Add stewards to footer

### DIFF
--- a/_layout/foot_general.html
+++ b/_layout/foot_general.html
@@ -26,6 +26,7 @@
       <ul>
         <li><a href="/community/">Community</a></li>
         <li><a href="/community/standards/">Code of Conduct</a></li>
+        <li><a href="/community/stewards/">Stewards</a></li>
         <li><a href="/diversity/">Diversity</a></li>
         <li><a href="https://juliagenderinclusive.github.io">Julia Gender Inclusive</a></li>
         <li><a href="https://juliacon.org">JuliaCon</a></li>


### PR DESCRIPTION
Lots of folks at JuliaCon didn't know the stewards are a thing. It is important for folks to know how to seek help in case of adverse behaviors on Julia discussion forums.

Adding directly below community standards because that is the primary domain of the stewards.