### PR TITLE
Add RISC-V to list of supported platforms

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -98,7 +98,7 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
       <td> <font color="green">Tier 1</font> </td>
     </tr>
     <tr>
-      <td rowspan="5"> Linux (Glibc) </td>
+      <td rowspan="6"> Linux (Glibc) </td>
       <td rowspan="5"> 2.6.24+ </td>
       <td> x86-64 (64-bit) </td>
       <td> <font color="green">Tier 1</font> </td>
@@ -116,11 +116,12 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
       <td> <font color="crimson">Tier 3</font> </td>
     </tr>
     <tr>
-      <td> PowerPC (64-bit)  </td>
+      <td> PowerPC (64-bit) </td>
       <td> <font color="crimson">Tier 3</font> </td>
     </tr>
     <tr>
-      <td> RISC-V (64-bit)  </td>
+      <td> 6.4+ </td>
+      <td> RISC-V (64-bit) </td>
       <td> <font color="crimson">Tier 3</font> </td>
     </tr>
     <tr>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -117,7 +117,11 @@ Different OSes and architectures have varying [tiers of support](/downloads/#sup
     </tr>
     <tr>
       <td> PowerPC (64-bit)  </td>
-      <td> <font color="crimson">Tier 3</font>  </td>
+      <td> <font color="crimson">Tier 3</font> </td>
+    </tr>
+    <tr>
+      <td> RISC-V (64-bit)  </td>
+      <td> <font color="crimson">Tier 3</font> </td>
     </tr>
     <tr>
       <td rowspan="1"> Linux (Musl) </td>


### PR DESCRIPTION
Added in https://github.com/JuliaLang/julia/pull/56105.

Since Julia currently builds for RISC-V and produces a functional REPL (but does not pass tests), there's docs how to do so, _and_ some manually-built binaries provided by me, I feel like Tier 3 fits best:

>  Tier 3: Julia may or may not build. If it does, it is unlikely to pass tests. Binaries may be available in some cases. When they are, they should be considered experimental. Ongoing support is dependent on community efforts. 