### PR TITLE
Fix link to package naming rules

### DIFF
--- a/contribute/developing_package.md
+++ b/contribute/developing_package.md
@@ -60,7 +60,7 @@ Now, to create the package, in the Julia REPL execute the following command:
 t("YourPackageName")
 ```
 
-Replace `YourPackageName` with the actual name of your package. Note that packages in Julia start with a capital letter. For more information on how to properly name your package, see [Package naming guidelines](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules).
+Replace `YourPackageName` with the actual name of your package. Note that packages in Julia start with a capital letter. For more information on how to properly name your package, see [Package naming rules](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules).
 
 After `PkgTemplates.jl` creates your new package, it stores the source files at  `~/.julia/dev` on Linux, and at `%USERNAME%/.julia/dev` on Windows. If this is not where you want to be working from, then move the source files to your preferred location. Your package directory contains the following:
 

--- a/contribute/developing_package.md
+++ b/contribute/developing_package.md
@@ -60,7 +60,7 @@ Now, to create the package, in the Julia REPL execute the following command:
 t("YourPackageName")
 ```
 
-Replace `YourPackageName` with the actual name of your package. Note that packages in Julia start with a capital letter. For more information on how to properly name your package, see [Package naming guidelines](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-guidelines).
+Replace `YourPackageName` with the actual name of your package. Note that packages in Julia start with a capital letter. For more information on how to properly name your package, see [Package naming guidelines](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules).
 
 After `PkgTemplates.jl` creates your new package, it stores the source files at  `~/.julia/dev` on Linux, and at `%USERNAME%/.julia/dev` on Windows. If this is not where you want to be working from, then move the source files to your preferred location. Your package directory contains the following:
 


### PR DESCRIPTION
Since the heading of the subsection changed from guidelines to rules, the link needed updating.