### PR TITLE
Bypass aka.ms/terminal terminal link that doesn't always work

### DIFF
--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -46,7 +46,7 @@ Julia installs all its files in a single directory. Deleting the directory where
 
 ## Windows
 
-Julia works best on 64-bit, and latest Windows 11 (you can expect terminal problems on default Windows 10), and is available for Windows 7 and later for both 32- and 64-bit versions.
+Julia is available for Windows 7 and later for both 32- and 64-bit versions.
 
 **We highly recommend running Julia using a modern terminal, such as installing the [Windows Terminal from the Microsoft Store](https://apps.microsoft.com/detail/9n0dx20hk701).**
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -46,7 +46,7 @@ Julia installs all its files in a single directory. Deleting the directory where
 
 ## Windows
 
-Julia is available for Windows 7 and later for both 32- and 64-bit versions.
+Julia is available for Windows 7 and later for both 32-bit and 64-bit versions.
 
 **We highly recommend running Julia using a modern terminal, such as installing the [Windows Terminal from the Microsoft Store](https://apps.microsoft.com/detail/9n0dx20hk701).**
 

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -46,9 +46,9 @@ Julia installs all its files in a single directory. Deleting the directory where
 
 ## Windows
 
-Julia is available for Windows 7 and later for both 32 bit and 64 bit versions.
+Julia works best on 64-bit, and latest Windows 11 (you can expect terminal problems on default Windows 10), and is available for Windows 7 and later for both 32- and 64-bit versions.
 
-**We highly recommend running Julia using a modern terminal, such as installing the [Windows Terminal from the Microsoft Store](https://aka.ms/terminal).**
+**We highly recommend running Julia using a modern terminal, such as installing the [Windows Terminal from the Microsoft Store](https://apps.microsoft.com/detail/9n0dx20hk701).**
 
 \newcommand{\winpath}{~~~<code>C:\Users\JohnDoe\AppData\Local\Programs\Julia-{{stable_release}}</code>~~~}
 \newcommand{\winpathbin}{~~~<code>C:\Users\JohnDoe\AppData\Local\Programs\Julia-{{stable_release}}\bin</code>~~~}


### PR DESCRIPTION
I get Service Unavailable, and assume the link redirected to is stable.

I see people are having issues still on Windows with terminal setup see: https://github.com/JuliaLang/juliaup/issues/528

Might juliaup recommend something on startup (for Windows users), or even download for users?