### PR TITLE
Remove last-modified date from foot_general.html

### DIFF
--- a/_layout/foot_general.html
+++ b/_layout/foot_general.html
@@ -45,7 +45,7 @@
     </div>
     <div id="footer-bottom" class="row">
       <div class="col-md-10 py-2">
-        <p>Last modified: {{ fill fd_mtime }}. This site is powered by <a href="https://www.netlify.com">Netlify</a>, <a href="https://franklinjl.org">Franklin.jl</a>, and the <a href="https://julialang.org">Julia Programming Language</a>.</p>
+        <p>This site is powered by <a href="https://www.netlify.com">Netlify</a>, <a href="https://franklinjl.org">Franklin.jl</a>, and the <a href="https://julialang.org">Julia Programming Language</a>.</p>
         <p>We thank <a href="https://www.fastly.com">Fastly</a> for their generous infrastructure support.</p>
         <p>©2024 JuliaLang.org <a href="https://github.com/JuliaLang/www.julialang.org/graphs/contributors">contributors</a>. The content on this website is made available under the <a href="https://github.com/JuliaLang/www.julialang.org/blob/master/LICENSE.md">MIT license</a>.</p>
       </div>


### PR DESCRIPTION
Because it is broken on the homepage (and last modified dates are also available via github)

Fixes #2136

https://github.com/JuliaLang/www.julialang.org/issues/2136#issuecomment-2595791388

Ideally this can be reverted with a PR that makes the homepage last modified date correct.