### PR TITLE
Correct headings for FastDifferentiation.jl GSoC

### DIFF
--- a/jsoc/gsoc/fast_differentiation.md
+++ b/jsoc/gsoc/fast_differentiation.md
@@ -1,12 +1,13 @@
+# FastDifferentiation.jl – Summer of Code
+
 [FastDifferentiation.jl](https://github.com/brianguenter/FastDifferentiation.jl) is a Julia package for computing very efficient symbolic derivatives of Julia functions and for compiling the derivatives into  efficient executables. It can differentiate much larger expressions than other symbolic systems, such as Symbolics.jl, and the resulting derivatives are also much more efficient, rivaling hand computed derivatives in some cases (see the website for benchmark examples).
 
 [FastDifferentiation.jl](https://github.com/brianguenter/FastDifferentiation.jl) also computes the exact sparsity patterns of Jacobians and Hessians (and any other order derivative) and detects common terms in derivatives of Rⁿ->Rᵐ functions for large n,m. As a consequence computation time of Jacobians generally scales sub-linearly as a function of n,m.
 
-
 However, the current system has several weaknesses. It is not currently possible to differentiate through conditional expressions so many commonly used Julia functions cannot be differentiated.
 Derivatives of any order can be computed but orders above 3 or 4 become increasingly inefficient. These projects aim to address these weaknesse.
 
-# Add Conditionals to FastDifferentiation.jl
+## Add Conditionals to FastDifferentiation.jl
 
 FastDifferentiation supports conditionals in function definitions but cannot yet compute derivatives of functions with conditionals:
 ```julia
@@ -29,7 +30,7 @@ ERROR: Your expression contained a if_else expression. FastDifferentiation does 
 
 **Mentor:** [BrianGuenter](https://github.com/brianguenter/FastDifferentiation.jl)
 
-# Add higher order derivatives to FastDifferentiation.jl
+## Add higher order derivatives to FastDifferentiation.jl
 FastDifferentiation.jl produces extremely efficient first derivatives. But, higher order derivatives become increasingly less efficient since they are computed by repeatedly applying the differentiation algorithm. 
 
 The fundamental cause of this behavior is that repeated higher order intermediate derivative terms are not detected and reused; instead they are computed from scratch. The goal of this project is to extend the FastDifferentiation algorithm to detect these common higher order terms and to reuse, rather than recompute them.
@@ -44,7 +45,7 @@ This will require a rewrite of the graph factorization code as well as some theo
 
 **Mentor:** [BrianGuenter](https://github.com/brianguenter/FastDifferentiation.jl)
 
-# Integrate FastDifferentiation.jl into Symbolics.jl
+## Integrate FastDifferentiation.jl into Symbolics.jl
 
 FastDifferentiation.jl uses a new symbolic algorithm for automatic differentiation that can be orders of magnitude faster than conventional symbolic differentiation methods. Symoblics.jl could compute derivatives much faster using the FastDifferentiation algorithm. However implementation and data structure differences between the two systems make it difficult to add FastDifferentiation capabilities to Symbolics.jl.
 


### PR DESCRIPTION
Currently, it shows up weirdly on the merged projects page -- it looks like it's part of the docs one:

![image](https://github.com/user-attachments/assets/1141e41c-3588-4611-afe8-60e5e90d5ea2)

cc @brianguenter