### PR TITLE
Re-add Documentation project ideas

### DIFF
--- a/jsoc/gsoc/documenter.md
+++ b/jsoc/gsoc/documenter.md
@@ -15,7 +15,7 @@ Here are some features or areas that are looking for contributions:
 
 If any of these sound interesting, please reach out to the mentors to ask for more details and to narrow down the project for a proposal. The possible projects vary in difficulty and size, depending on the project and the ultimate scope.
 
-**Recommended skills**: Depends on the project, but the work would generally involved both Julia programming, but also basic web developments (HTML, CSS, JS).
+**Recommended skills**: Depends on the project, but the work would generally involved both Julia programming, but also basic web development (HTML, CSS, JS).
 
 **Mentors:** [Morten Piibeleht](https://github.com/mortenpi), [Fredrik Ekre](https://github.com/fredrikekre)
 

--- a/jsoc/gsoc/documenter.md
+++ b/jsoc/gsoc/documenter.md
@@ -12,7 +12,6 @@ Here are some features or areas that are looking for contributions:
 * Rework Documenter's page layout and navigation. See [JuliaDocs/Documenter.jl#2177](https://github.com/JuliaDocs/Documenter.jl/issues/2177).
 * Improve or rework Documenter's search index.
 * Work on any of the ideas that have been [marked as plugins](https://github.com/JuliaDocs/Documenter.jl/labels/Type%3A%20Plugin), as they offer self-contained features to work on.
-* Improve Documenter's own documentation.
 
 If any of these sound interesting, please reach out to the mentors to ask for more details and to narrow down the project for a proposal. The possible projects vary in difficulty and size, depending on the project and the ultimate scope.
 

--- a/jsoc/gsoc/documenter.md
+++ b/jsoc/gsoc/documenter.md
@@ -17,7 +17,7 @@ If any of these sound interesting, please reach out to the mentors to ask for mo
 
 **Recommended skills**: Depends on the project, but the work would generally involved both Julia programming, but also basic web developments (HTML, CSS, JS).
 
-**Mentors:** [Morten Piibeleht](https://github.com/mortenpi), [Fredrik-Ekre](https://github.com/fredrikekre)
+**Mentors:** [Morten Piibeleht](https://github.com/mortenpi), [Fredrik Ekre](https://github.com/fredrikekre)
 
 ## Contact
 

--- a/jsoc/gsoc/documenter.md
+++ b/jsoc/gsoc/documenter.md
@@ -14,7 +14,7 @@ Here are some features or areas that are looking for contributions:
 * Work on any of the ideas that have been [marked as plugins](https://github.com/JuliaDocs/Documenter.jl/labels/Type%3A%20Plugin), as they offer self-contained features to work on.
 * Improve Documenter's own documentation.
 
-If any of these sound interesting, please reach out to the mentors to ask for more details and to narrow down the project for a proposal.
+If any of these sound interesting, please reach out to the mentors to ask for more details and to narrow down the project for a proposal. The possible projects vary in difficulty and size, depending on the project and the ultimate scope.
 
 **Recommended skills**: Depends on the project, but the work would generally involved both Julia programming, but also basic web developments (HTML, CSS, JS).
 

--- a/jsoc/gsoc/documenter.md
+++ b/jsoc/gsoc/documenter.md
@@ -3,3 +3,23 @@
 ## Documenter.jl
 
 The Julia manual and the documentation for a large chunk of the ecosystem is generated using [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) -- essentially a static site generator that integrates with Julia and its docsystem. There are tons of opportunities for improvements for anyone interested in working on the interface of Julia, documentation and various front-end technologies (web, LaTeX).
+
+Here are some features or areas that are looking for contributions:
+
+* User-contributed notes and examples to documentation (e.g. backed by GitHub Discussions).
+* One-page-per-function documentation listings (prototype for main Julia manual). See [JuliaDocs/Documenter.jl#2133](https://github.com/JuliaDocs/Documenter.jl/issues/2133).
+* JuliaSyntax-based code highlighter for Julia code that can be re-used for both the HTML and LaTeX/PDF output.
+* Rework Documenter's page layout and navigation. See [JuliaDocs/Documenter.jl#2177](https://github.com/JuliaDocs/Documenter.jl/issues/2177).
+* Improve or rework Documenter's search index.
+* Work on any of the ideas that have been [marked as plugins](https://github.com/JuliaDocs/Documenter.jl/labels/Type%3A%20Plugin), as they offer self-contained features to work on.
+* Improve Documenter's own documentation.
+
+If any of these sound interesting, please reach out to the mentors to ask for more details and to narrow down the project for a proposal.
+
+**Recommended skills**: Depends on the project, but the work would generally involved both Julia programming, but also basic web developments (HTML, CSS, JS).
+
+**Mentors:** [Morten Piibeleht](https://github.com/mortenpi), [Fredrik-Ekre](https://github.com/fredrikekre)
+
+## Contact
+
+Best way to reach out is to message in the `#documentation` channel on the [JuliaLang Slack](https://julialang.org/slack/)!

--- a/jsoc/projects.md
+++ b/jsoc/projects.md
@@ -7,7 +7,7 @@ We have our project ideas organized below roughly by domain but you can also see
 @@tight-list
 * [Compiler](/jsoc/gsoc/compiler/) – work on the Julia compiler's internals to make things better for everyone.
 * [CliMA](/jsoc/gsoc/clima/) – a new open-source climate model that runs on GPUs.
-<!--* [Documentation tooling](/jsoc/gsoc/documenter/) - Tooling related to documentation generation, docstrings etc.-->
+* [Documentation tooling](/jsoc/gsoc/documenter/) - Tooling related to documentation generation, docstrings etc.
 * [Ferrite FEM](/jsoc/gsoc/ferrite-fem/) - A modern finite element toolbox in Julia.
 * [Gabs](/jsoc/gsoc/gabs/) - A Gaussian quantum information simulator
 * [Graph neural networks](/jsoc/gsoc/gnn/) - Deep learning on graphs with GraphNeuralNetworks.jl.


### PR DESCRIPTION
Re-enables the Documentation Tooling section and adds some very basic projects ideas and references to mentors.

Ideally, the project ideas would be a bit more fleshed out. But we wanted to have something up. So this is more a "hey, you can work on this stuff too" list right now.

cc @fredrikekre
