### PR TITLE
Reinsert mention of JuliaCon Paris 2025 in newsletter

### DIFF
--- a/blog/2025/03/this-month-in-julia-world.md
+++ b/blog/2025/03/this-month-in-julia-world.md
@@ -6,6 +6,10 @@
 
 A monthly newsletter, mostly on julia internals, digestible for casual observers. A biased, incomplete, editorialized list of what I found interesting this month, with contributions from the community.
 
+> Save the date for JuliaCon Local Paris 2025 (October 2nd-3rd)!
+>
+> More information at **<https://juliacon.org/local/paris2025/>**
+
 “Internals” Fora and Core Repos (Slack/Zulip/Discourse/Github):
 
 * Revise is almost ready to work on structs, not just functions… This went from “never going to happen” to “standard feature” in the blink of an eye. See [slack discussion](https://julialang.slack.com/archives/C03D578FCDD/p1738836742511929) and the [last PR in the series](https://github.com/JuliaLang/julia/pull/57253).


### PR DESCRIPTION
Cleared with @Krastanov beforehand. The mention was inserted in #2259 but the conference was only announced today, which is why we removed it in #2264.