### PR TITLE
Create Install page focused on juliaup installation

### DIFF
--- a/_layout/foot_general.html
+++ b/_layout/foot_general.html
@@ -9,7 +9,8 @@
         <li><a href="/community/sponsors/">Sponsors</a></li>
       </ul>
       <ul>
-        <li><a href="/downloads/">Downloads</a></li>
+        <li><a href="/install/">Downloads</a></li>
+        <li><a href="/install/">Install</a></li>
         <li><a href="/downloads/">All Releases</a></li>
         <li><a href="https://github.com/JuliaLang/julia">Source Code</a></li>
         <li><a href="/downloads/#current_stable_release">Current Stable Release</a></li>

--- a/_layout/foot_general.html
+++ b/_layout/foot_general.html
@@ -9,9 +9,8 @@
         <li><a href="/community/sponsors/">Sponsors</a></li>
       </ul>
       <ul>
-        <li><a href="/install/">Downloads</a></li>
         <li><a href="/install/">Install</a></li>
-        <li><a href="/downloads/">All Releases</a></li>
+        <li><a href="/downloads/">Manual Downloads</a></li>
         <li><a href="https://github.com/JuliaLang/julia">Source Code</a></li>
         <li><a href="/downloads/#current_stable_release">Current Stable Release</a></li>
         <li><a href="/downloads/#long_term_support_release">Longterm Support Release</a></li>

--- a/_layout/navbar.html
+++ b/_layout/navbar.html
@@ -9,10 +9,10 @@
       <div class="collapse navbar-collapse" id="navbarContent">
           <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
               <li class="nav-item">
-                  <a class="nav-link" href="/downloads/">Download</a>
+                  <a class="nav-link" href="/install/">Install</a>
               </li>
               <li class="nav-item">
-                  <a class="nav-link" href="https://docs.julialang.org">Documentation</a>
+                  <a class="nav-link" href="https://docs.julialang.org">Docs</a>
               </li>
               <li class="nav-item">
                   <a class="nav-link" href="/learning/">Learn</a>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -1,59 +1,8 @@
 @def title = "Download Julia"
 
-~~~
-  <div>
-   <div>
-    <h2 id="install_julia"> <a href="#install_julia">Install <img src="/assets/infra/logo.svg" class="julialogo inline-h2-julia-logo" alt="Julia"></img></h2></a>
-    <div class="container pt-sm-2">
-      <div class="row" id="windows-instructions" style="display: none;">
-        Install the latest Julia version (<a href="#current_stable_release">v{{stable_release}}</a>{{stable_release_date}}) from the <a href="https://www.microsoft.com/store/apps/9NJNWW8PVKMN">Microsoft Store</a> by running this in the command prompt:
-        <pre><code class="language-plaintext cmdprompt-block">winget install --name Julia --id 9NJNWW8PVKMN -e -s msstore</code></pre>
-        <div class="install-platform-note"><span id="platform-subnote-windows">It looks like you're using Windows. </span>For Linux and MacOS instructions <a onclick="showOther()" href="javascript:void(0);">click here</a></div>
-      </div>
-      <div class="row" id="other-platforms-instructions" style="display: none;">
-        Install the latest Julia version (<a href="#current_stable_release">v{{stable_release}}</a>{{stable_release_date}}) by running this in your terminal:
-        <pre><code class="language-plaintext bash-block">curl -fsSL https://install.julialang.org | sh</code></pre>
-        <div class="install-platform-note"><span id="platform-subnote-other">It looks like you're using a Unix/Linux-type system. </span>For Windows instructions <a onclick="showWindows()" href="javascript:void(0);">click here</a></div>
-      </div>
-    </div>
-    <script>
-      function showWindows() {
-        document.getElementById('windows-instructions').style.display = 'block';
-        document.getElementById('other-platforms-instructions').style.display = 'none';
-      }
-      function showOther() {
-        document.getElementById('windows-instructions').style.display = 'none';
-        document.getElementById('other-platforms-instructions').style.display = 'block';
-      }
-      var isWindows = navigator.platform.indexOf('Win') > -1;
-      if (isWindows) {
-        document.getElementById('platform-subnote-other').style.display = 'none';
-        showWindows();
-      } else {
-        document.getElementById('platform-subnote-windows').style.display = 'none';
-        showOther();
-      }
-    </script>
-~~~
+# Manual Downloads
 
-Once installed `julia` will be available via the command line interface.
-
-This will install the [Juliaup](https://github.com/JuliaLang/juliaup) installation manager, which will automatically install julia and help keep it up to date. The command `juliaup` is also installed. To install different julia versions see `juliaup --help`.
-
----
-
-Please star us [on GitHub](https://github.com/JuliaLang/julia). If you use Julia in your research, please [cite us](https://julialang.org/research/). If possible, do consider [sponsoring](https://github.com/sponsors/julialang) us.
-
-~~~
-   </div>
-  </div>
-~~~
-
----
-
-### Manual Download
-
-Please see [platform specific instructions](/downloads/platform/) for further manual installation instructions. If the official binaries do not work for you, please [file an issue in the Julia project](https://github.com/JuliaLang/julia/issues).
+**This page is not for most users:** See [Install](/install/) for how to install Julia the recommended way using `juliaup`. Please see [platform specific instructions](/downloads/platform/) for further manual installation instructions. If the official binaries do not work for you, please [file an issue in the Julia project](https://github.com/JuliaLang/julia/issues).
 
 ~~~
 <h4 id=current_stable_release><a href="#current_stable_release">Current stable release: v{{stable_release}} ({{stable_release_date}})</a></h4>
@@ -518,18 +467,3 @@ All Julia binary releases are cryptographically secured using the traditional me
 ### JSON release feed
 
 The info above is also available as a [JSON file](https://julialang-s3.julialang.org/bin/versions.json) ([schema](https://julialang-s3.julialang.org/bin/versions-schema.json)). It may take up to two hours after the release of a new version for it to be included in the JSON file.
-
-### IP address retention policy
-<!--
-IF YOU'RE THINKING ABOUT REMOVING THIS NOTE, DON'T. ACCORDING TO OUR LAWYERS, THIS NEEDS TO BE HERE TO COMPLY WITH THE GDPR. YES, IT'S STUPID. I DON'T MAKE THE RULES.
--->
-Julia comes with a built-in package manager which downloads and installs packages from the Internet. In doing so, it necessarily reveals your public [IP address](https://en.wikipedia.org/wiki/IP_address) to any server you connect to, and service providers may log your IP address. In Julia versions 1.5 and higher, by default the package manager connects to <https://pkg.julialang.org>, a free public service operated by the Julia project to serve open source package resources to Julia users. This service retains IP address logs for up to 31 days.
-
-### Official domains
-
-The following domains are official and used by open source Julia infrastructure for serving content and resources:
-
-- `julialang.org` and all subdomains
-- `julialang.net` and all subdomains
-
-If you are using Julia behind a firewall that blocks access to these, you may have trouble downloading and installing Julia packages. If this is the case, please ask your sysadmin to add these domains to the firewall allow list. Traffic can be limited to HTTPS (TCP port 443).

--- a/downloads/platform.md
+++ b/downloads/platform.md
@@ -119,6 +119,6 @@ To launch Julia, simply type `julia` inside your shell and press return.
 
 You can uninstall Julia by deleting Julia.app and the packages directory in `~/.julia`. Multiple Julia.app binaries can co-exist without interfering with each other. If you would also like to remove your preferences files, remove `~/.julia/config/startup.jl` and `~/.julia/logs/repl_history.jl`.
 
-# A Brief Note About Unofficial Binaries
+## A Brief Note About Unofficial Binaries
 
 There are a variety of distribution-specific packages that are community contributed. They may not use the right versions of Julia dependencies or include important patches that the official binaries ship with. All such distributions are community maintained, and hence they may not always have the latest versions of Julia, and sometimes, the instructions may not work. In general, bug reports will only be accepted if they are reproducible on the official generic binaries on the downloads page.

--- a/index.html
+++ b/index.html
@@ -35,9 +35,9 @@
         The Julia Programming Language
       </h1>
       <p>
-      <a class="btn btn-success btn-lg" href="/downloads/" role="button">Download</a>
+      <a class="btn btn-success btn-lg" href="/install/" role="button">Install</a>
       &nbsp;
-      <a class="btn btn-primary btn-lg" href="https://docs.julialang.org" role="button">Documentation</a>
+      <a class="btn btn-primary btn-lg" href="https://docs.julialang.org" role="button">Docs</a>
       <span class="btn float-md-right">
         <a class="github-button" href="https://github.com/JuliaLang/julia" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star JuliaLang/julia on GitHub">Star</a>
       </span>

--- a/install/index.md
+++ b/install/index.md
@@ -1,0 +1,57 @@
+@def title = "Download Julia"
+
+# Installing Julia
+
+The recommended way to install Julia is to install [`juliaup`](https://github.com/JuliaLang/juliaup) which is a small, self-contained binary that will automatically install the latest stable `julia` binary and help keep it up to date. It also supports installing and using different versions of Julia simultaneously.
+~~~
+<div id="windows-instructions" style="display: none;">
+  Install <code>juliaup</code> from the <a href="https://www.microsoft.com/store/apps/9NJNWW8PVKMN">Microsoft Store</a> by running this in the command prompt:
+  <pre><code class="language-plaintext cmdprompt-block">winget install --name Julia --id 9NJNWW8PVKMN -e -s msstore</code></pre>
+  <div class="install-platform-note"><span id="platform-subnote-windows">It looks like you're using Windows. </span>For Linux and MacOS instructions <a onclick="showUNIX()" href="javascript:void(0);">click here</a></div>
+</div>
+<div id="unix-instructions" style="display: none;">
+  Install <code>juliaup</code> by running this in your terminal:
+  <pre><code class="language-plaintext bash-block">curl -fsSL https://install.julialang.org | sh</code></pre>
+  <div class="install-platform-note"><span id="platform-subnote-unix">It looks like you're using a Unix-type system. </span>For Windows instructions <a onclick="showWindows()" href="javascript:void(0);">click here</a></div>
+</div>
+<script>
+  function showWindows() {
+    document.getElementById('windows-instructions').style.display = 'block';
+    document.getElementById('unix-instructions').style.display = 'none';
+  }
+  function showUNIX() {
+    document.getElementById('windows-instructions').style.display = 'none';
+    document.getElementById('unix-instructions').style.display = 'block';
+  }
+  var isWindows = navigator.platform.indexOf('Win') > -1;
+  if (isWindows) {
+    document.getElementById('platform-subnote-unix').style.display = 'none';
+    showWindows();
+  } else {
+    document.getElementById('platform-subnote-windows').style.display = 'none';
+    showUNIX();
+  }
+</script>
+~~~
+
+This will install the latest stable version of Julia, which can be launched from a command-line by typing `julia` as well as the `juliaup` tool. To install different julia versions see `juliaup --help`.
+
+Please star us [on GitHub](https://github.com/JuliaLang/julia). If you use Julia in your research, please [cite us](/research/). If possible, do consider [sponsoring](https://github.com/sponsors/julialang) us.
+
+If you want to manually download and install specific Julia versions, see the [Downloads](/downloads/) page. You can also find out more details about [supported platforms](/downloads/#supported_platforms).
+
+### IP Address Retention Policy
+<!--
+IF YOU'RE THINKING ABOUT REMOVING THIS NOTE, DON'T. ACCORDING TO OUR LAWYERS, THIS NEEDS TO BE HERE TO COMPLY WITH THE GDPR. YES, IT'S STUPID. I DON'T MAKE THE RULES.
+-->
+Julia comes with a built-in package manager which downloads and installs packages from the Internet. In doing so, it necessarily reveals your public [IP address](https://en.wikipedia.org/wiki/IP_address) to any server you connect to, and service providers may log your IP address. In Julia versions 1.5 and higher, by default the package manager connects to <https://pkg.julialang.org>, a free public service operated by the Julia project to serve open source package resources to Julia users. This service retains IP address logs for up to 31 days.
+
+### Official domains
+
+The following domains are official and used by open source Julia infrastructure for serving content and resources:
+
+- `julialang.org` and all subdomains
+- `julialang.net` and all subdomains
+
+If you are using Julia behind a firewall that blocks access to these, you may have trouble downloading and installing Julia packages. If this is the case, please ask your sysadmin to add these domains to the firewall allow list. Traffic can be limited to HTTPS (TCP port 443).
+


### PR DESCRIPTION
This addresses the "banner fatigue" issue that was causing people to skip the `juliaup` instructions and reduces the amount of irrelevant text people see in the course of just trying to install Julia. Most people should not be doing manual downloads these days. See also #2282. We may want to include some of @Eben60's wording changes from that PR.