### PR TITLE
Restore header underlines for current section (fix #2276)

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -13,8 +13,7 @@
   background-color: #fff;
   border-bottom: 0;
 }
-#main-menu .nav-item.active,
-#main-menu .nav-item:hover {
+#main-menu .nav-item.active {
   border-bottom-color: #ca3c32;
 }
 .navbar-light .navbar-nav .nav-link {

--- a/_layout/navbar.html
+++ b/_layout/navbar.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-white">
+<nav class="navbar navbar-expand-lg navbar-light bg-white" id="main-menu">
   <div class="container">
       <a class="navbar-brand" href="/">
           <img src="/assets/infra/logo.svg" alt="JuliaLang Logo" height="40">
@@ -8,25 +8,25 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarContent">
           <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
-              <li class="nav-item">
+              <li class="nav-item {{ispage /install/*}}active{{end}} {{ispage /downloads/*}}active{{end}}">
                   <a class="nav-link" href="/install/">Install</a>
               </li>
               <li class="nav-item">
                   <a class="nav-link" href="https://docs.julialang.org">Docs</a>
               </li>
-              <li class="nav-item">
+              <li class="nav-item {{ispage /learning/*}}active{{end}}">
                   <a class="nav-link" href="/learning/">Learn</a>
               </li>
-              <li class="nav-item">
+              <li class="nav-item {{ispage /blog/*}}active{{end}}">
                   <a class="nav-link" href="/blog/">Blog</a>
               </li>
-              <li class="nav-item">
+              <li class="nav-item {{ispage /community/*}}active{{end}}">
                   <a class="nav-link" href="/community/">Community</a>
               </li>
-              <li class="nav-item">
+              <li class="nav-item {{ispage /contribute/*}}active{{end}}">
                   <a class="nav-link" href="/contribute/">Contribute</a>
               </li>
-              <li class="nav-item">
+              <li class="nav-item {{ispage /jsoc/*}}active{{end}}">
                   <a class="nav-link" href="/jsoc/">JSoC</a>
               </li>
           </ul>


### PR DESCRIPTION
My CSS skills are very limited, but this seems to mostly fix the regression introduced by https://github.com/JuliaLang/www.julialang.org/pull/2235.