### PR TITLE
Don't underline <h?> elements

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -422,6 +422,9 @@ h4.card-title {
   text-shadow: 1px 1px 2px #0a0a0a;
 }
 
+a.header-anchor {
+  text-decoration: none;
+}
 
 .link {
   color: #4D64AE;


### PR DESCRIPTION
These were made into `<a>` anchor elements at some point, which caused them to be underlined. This adds a CSS rule to remove that underline. Fixes https://github.com/JuliaLang/www.julialang.org/issues/2276.