### PR TITLE
Update `check_orgs.jl`: Handle errors; also, remove an org that no longer exists (JuliaAstrodynamics)

### DIFF
--- a/community/organizations.md
+++ b/community/organizations.md
@@ -104,7 +104,6 @@ The following is a non-comprehensive list of Julia GitHub organizations, grouped
 ### Astronomy/Space
 
 * [JuliaAstro](https://github.com/JuliaAstro) – [Astronomy](https://juliaastro.github.io/)
-* [JuliaAstrodynamics](https://github.com/JuliaAstrodynamics)
 * [juliahci](https://github.com/juliahci) – High-contrast imaging
 * [JuliaSpace](https://github.com/JuliaSpace)
 

--- a/tools/check_orgs/check_orgs.jl
+++ b/tools/check_orgs/check_orgs.jl
@@ -19,7 +19,13 @@ function check_orgs()
     for org_match in orgs
         org = split(org_match.captures[1], "https://github.com/", keepempty=false)[1]
         org = split(org, "http://github.com/", keepempty=false)[1]
-        members, page_data = GitHub.members(Owner(org), auth=myauth, public_only=true)
+        members = -1
+        try
+            members, page_data = GitHub.members(Owner(org), auth=myauth, public_only=true)
+        catch e
+            err_msg = sprint(showerror, e)
+            println("Error processing organization '$org':\n$err_msg")
+        end
         if length(members) < 2
             println(" - $org $(length(members)) members")
             num_below += 1

--- a/tools/check_orgs/check_orgs.jl
+++ b/tools/check_orgs/check_orgs.jl
@@ -19,14 +19,14 @@ function check_orgs()
     for org_match in orgs
         org = split(org_match.captures[1], "https://github.com/", keepempty=false)[1]
         org = split(org, "http://github.com/", keepempty=false)[1]
-        members = -1
+        members = nothing
         try
             members, page_data = GitHub.members(Owner(org), auth=myauth, public_only=true)
         catch e
             err_msg = sprint(showerror, e)
             println("Error processing organization '$org':\n$err_msg")
         end
-        if length(members) < 2
+        if isnothing(members) || length(members) < 2
             println(" - $org $(length(members)) members")
             num_below += 1
         end


### PR DESCRIPTION
Fix #2298

- Update `check_orgs.jl`: Handle errors
- Remove 404 Org: https://github.com/JuliaAstrodynamics

### TODO
Keep:
- [JuliaNLSolvers](https://github.com/JuliaNLSolvers) 1 members: Last Update 4 days ago
- [JuliaNonconvex](https://github.com/JuliaNonconvex) 1 members: Updated on Nov 22, 2024
- [juliahci](https://github.com/juliahci) 1 members: Updated on Dec 28, 2024

Remove:
- [JuliaPraxis](https://github.com/JuliaPraxis) 0 members: Last Update 2019
- [JuliaActors](https://github.com/JuliaActors) 0 members: Last Update 2021
- [JuliaQuantum](https://github.com/JuliaQuantum) 1 members: Last Update 2023
