### PR TITLE
link  that open store

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -5,7 +5,7 @@
 The recommended way to install Julia is to install [`juliaup`](https://github.com/JuliaLang/juliaup) which is a small, self-contained binary that will automatically install the latest stable `julia` binary and help keep it up to date. It also supports installing and using different versions of Julia simultaneously.
 ~~~
 <div id="windows-instructions" style="display: none;">
-  Install <code>juliaup</code> from the <a href="https://www.microsoft.com/store/apps/9NJNWW8PVKMN">Microsoft Store</a> by running this in the command prompt:
+  Install <code>juliaup</code> from the <a href="https://apps.microsoft.com/detail/9njnww8pvkmn?launch=true&mode=full">Microsoft Store</a> by running this in the command prompt:
   <pre><code class="language-plaintext cmdprompt-block">winget install --name Julia --id 9NJNWW8PVKMN -e -s msstore</code></pre>
   <div class="install-platform-note"><span id="platform-subnote-windows">It looks like you're using Windows. </span>If you cannot access the Microsoft Store, try the experimental <a href="https://install.julialang.org/Julia.appinstaller">MSIX App Installer</a>. For Linux and MacOS instructions <a onclick="showUNIX()" href="javascript:void(0);">click here</a></div>
 </div>


### PR DESCRIPTION
After reading https://discourse.julialang.org/t/a-graphical-julia-installer-for-windows/128413/48?u=xgdgsc I found the old link shows a "Not found" for me. So I found this new link that opens the store app.