### PR TITLE
List Julia Package Comparisons on packages

### DIFF
--- a/packages/index.md
+++ b/packages/index.md
@@ -6,4 +6,5 @@ The Julia ecosystem contains over 10,000 packages that are registered in the [Ge
 * [JuliaHub](https://juliahub.com/ui/Packages) — a [JuliaHub](https://juliahub.com) service that includes search of all registered open source package documentation, code search, and navigation by tags/keywords.
 * [Julia Packages](https://juliapackages.com) — browse Julia packages, filter by categories, and sort them by popularity, creation date or date of last update. Also supports browsing package developers.
 * [Julia.jl](https://github.com/svaksha/Julia.jl) — a manually curated taxonomy of Julia packages (category information for JuliaPackages is derived from this as well).
+* [Julia Package Comparisons](https://juliapackagecomparisons.github.io) - a website to help Julia users discover and choose between packages.
 @@


### PR DESCRIPTION
We are refreshing the [Julia Package Comparisons](https://juliapackagecomparisons.github.io/) as discussed [here](https://discourse.julialang.org/t/juliapackagecomparisons-is-looking-for-a-new-maintainer/130667)

It would be great to have it included on the packages page: https://julialang.org/packages/

@LilithHafner , you asked to be pinged back on #2037 , hope you are still interested :smile:

Ref https://github.com/JuliaLang/julia/issues/53068

Closes https://github.com/JuliaPackageComparisons/JuliaPackageComparisons.github.io/issues/2

CC @KronosTheLate