### PR TITLE
Add JuliaLangJa to groups.js

### DIFF
--- a/_libs/groups.js
+++ b/_libs/groups.js
@@ -59,4 +59,11 @@ const groups = [
         lon: 12.599143,
         homepage: 'https://www.meetup.com/copenhagen-julia-meetup-group',
     },
+    {
+        name: 'JuliaLangJa',
+        lat: 35.684115230694495,
+        lon: 139.77453110558406,
+        homepage: 'https://julialangja.github.io/',
+        github: 'https://github.com/JuliaLangJa',
+    },
 ];


### PR DESCRIPTION
We would like to add @JuliaLangJa to the local communities map. The coordinates correspond to [Japan’s Kilometre Zero (日本国道路元標, Nipponkoku Dōro Genpyō)](https://maps.app.goo.gl/CceomqMstxEnADPg7). Thanks!

<img width="1905" height="1000" alt="image" src="https://github.com/user-attachments/assets/ab3cb960-ac63-4063-9210-dda021f1d1a3" />
