### PR TITLE
Change Windows WSL2 tier from 3 to 2

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -424,7 +424,7 @@ Julia also supports a variety of hardware accelerators, by means of external pac
     <tr>
       <td> Windows (64-bit) </td>
       <td> WSL2 </td>
-      <td> <font color="crimson">Tier 3</font> </td>
+      <td> <font color="crimson">Tier 2</font> </td>
     </tr>
     <tr>
       <td rowspan="2"> <a href="https://juliagpu.org/backends/rocm">AMD GPUs using ROCm</a> </td>


### PR DESCRIPTION
WSL 2 got tier 2 support recently. Does the GPU package inherit it? Oversight or intentionally tier 3? Should it also state Ubuntu? I think official support is conservative, and probably most distros just work (assuming, and not just meaning with GPUs).