### PR TITLE
Amend the language around manual downloads and make it more prominent

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -1,8 +1,8 @@
 @def title = "Download Julia"
 
-# Manual Downloads (Not recommended for typical installations)
+\note{Prefer juliaup for typical installations}{See the [installation instructions](/install/) on using `juliaup` to install the official Julia binaries. Users who require a specific, atypical setup may manually download and install the official binaries from this page. If the official binaries do not work for you, please [file an issue in the Julia project](https://github.com/JuliaLang/julia/issues).}
 
-\note{juliaup is the proper way to install julia, not these downloads}{See the [installation instructions](/install/) on using `juliaup` to install Julia. If the official binaries do not work for you, please [file an issue in the Julia project](https://github.com/JuliaLang/julia/issues).}
+# Manual Downloads
 
 ~~~
 <h4 id=current_stable_release><a href="#current_stable_release">Current stable release: v{{stable_release}} ({{stable_release_date}})</a></h4>


### PR DESCRIPTION
#2382 made the language around manually downloading the official Julia binaries fairly aggressive, but perhaps unnecessarily so. The concern that motivated that PR was that newer users were manually downloading these binaries rather than managing their installations via JuliaUp. There is nothing inherently wrong with that method, however, though it is much less convenient for the user.

To make the this warning friendlier to users who know what they're doing and have specific requirements that motivate this workflow (or otherwise just prefer it), we can soften the language a bit and make it a bit more specific, but also make the warning itself more prominent on the page by putting it above the "Manual Downloads" heading.

@Krastanov, I would love your thoughts on this approach and whether you think it strikes a reasonable balance with your needs.