### PR TITLE
Windows Julia install command typo corrected to read `msstore`.

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -5,7 +5,7 @@
 ~~~
 <div id="windows-instructions" style="display: none;">
   Install Julia using the <a href="https://install.julialang.org/Julia.appinstaller">MSIX App Installer</a>. Alternatively, if you have access to the <a href="https://www.microsoft.com/store/apps/9NJNWW8PVKMN">Microsoft Store</a>, you can install Julia by running the following in the command prompt:<br><br>
-  <pre><code class="language-plaintext cmdprompt-block">winget install --name Julia --id 9NJNWW8PVKMN -e -s masstore</code></pre>
+  <pre><code class="language-plaintext cmdprompt-block">winget install --name Julia --id 9NJNWW8PVKMN -e -s msstore</code></pre>
   <div class="install-platform-note"><span id="platform-subnote-windows">It looks like you are using Windows. </span>
   For Linux and MacOS instructions <a onclick="showUNIX()" href="javascript:void(0);">click here</a>.</div>
 </div>


### PR DESCRIPTION
"msstore" is the correct string to pass to `winget` for its `-s` flag.