### PR TITLE
Refactor blog title header layout 

### DIFF
--- a/_css/franklin.css
+++ b/_css/franklin.css
@@ -13,24 +13,38 @@
     margin-bottom: 0;
 }
 
-.container.blog-title h1 {
+.container.blog-title .blog-title-wrapper {
   display: flex;
-  gap: 0.5rem;
-  max-width: 40ch;
+  align-items: flex-start;
+  width: 100%;
 }
 
-.container h3 {
-    margin-top: 0.8em;
+.container.blog-title .blog-title-left {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.container.blog-title .blog-title-right {
+  flex: 0 0 auto;
+  display: flex;
+  margin-left: 1rem;
 }
 
 .container.blog-title .rss-link {
-  margin-top: 9px;
-  font-size: 0.75em;
+  margin-top: 18px;
+  margin-right: 15px;
+  font-size: 1.5em;
+}
+
+.container.blog-title h1 {
+  font-size: 3em;
 }
 
 .container.blog-title h3 {
-    font-size: 18px;
-    margin-bottom: 1em;
+  margin-top: 0.3em;
+  margin-bottom: 1em;
+  font-size: 18px;
 }
 
 .author-info {

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -38,7 +38,7 @@
     .main pre code { font-size: 90%; }
     @media (min-width: 940px) {
       .main { width: 800px; }
-      .container.blog-title { width: 800px;}
+      .blog-title { width: 800px;}
     }
   </style>
   {{end}}{{end}}
@@ -56,21 +56,36 @@
 
 {{ispage /blog/*}}
 <div class="container blog-title">
-  {{isdef title}}<h1>{{fill title}}
-    <a type="application/rss+xml"
-      href="https://julialang.org/feed.xml"
-      class="rss-link">
-      <i class="fa fa-rss-square rss-icon"></i>
-    </a>
-  </h1>{{end}}
-  <h3>
-  {{isdef published}} <span style="font-weight: lighter;"> {{fill published}} </span>
-	|
-	{{end}}
-	{{isdef author}} <span style="font-weight: bold;">{{fill author}}{{author_twitter}}</span> {{end}}
-  <!-- assumption that only one of the two is defined -->
-  {{isdef authors}} <span style="font-weight: bold;">{{fill authors}} </span> {{end}}
-  </h3>
+  <div class="blog-title-wrapper">
+    <div class="blog-title-left">
+      <div class="blog-title-heading">
+        {{isdef title}}
+          <h1>{{fill title}}</h1>
+        {{end}}
+      </div>
+      <div class="blog-title-meta">
+        <h3>
+          {{isdef published}}
+            <span style="font-weight: lighter;">{{fill published}}</span> |
+          {{end}}
+          {{isdef author}}
+            <span style="font-weight: bold;">{{fill author}}{{author_twitter}}</span>
+          {{end}}
+          {{isdef authors}}
+            <span style="font-weight: bold;">{{fill authors}}</span>
+          {{end}}
+        </h3>
+      </div>
+    </div>
+
+    <div class="blog-title-right">
+      <a type="application/rss+xml"
+         href="https://julialang.org/feed.xml"
+         class="rss-link">
+        <i class="fa fa-rss-square rss-icon"></i>
+      </a>
+    </div>
+  </div>
 </div>
 {{end}}
 


### PR DESCRIPTION
before :
<img width="1898" height="716" alt="Screenshot 2025-12-15 185203" src="https://github.com/user-attachments/assets/d96203f6-94d4-4ad6-a39f-874ab0be75d1" />

after : 
<img width="1901" height="917" alt="Screenshot 2025-12-15 185219" src="https://github.com/user-attachments/assets/bc3ec66b-eeac-4d0a-856c-0a00cec98f7e" />

this pr does:
- Separates title + meta (date/author) from the RSS link
- Uses a scoped flex-based structure for predictable alignment


the changes reflected: 

https://github.com/user-attachments/assets/d61af520-9f62-4aca-9ac4-7e25f7e1faab
