### PR TITLE
Fix JuliaCon 2025 playlist link

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@ end
     <div class="row">
       <div class="col-12 text-center">
         <a class="btn btn-sm btn-outline-primary" href="https://www.youtube.com/user/JuliaLanguage">Julia Channel on YouTube</a>
-        <a class="btn btn-sm btn-outline-primary" href="https://www.youtube.com/playlist?list=PLP8iPy9hna6R5gUZLbSZCZTGJ0uncLBfi">JuliaCon 2025 videos</a>
+        <a class="btn btn-sm btn-outline-primary" href="https://www.youtube.com/playlist?list=PLP8iPy9hna6SZOq4EH_nE_BFulBAKXkf1">JuliaCon 2025 videos</a>
         <a class="btn btn-sm btn-outline-primary" href="https://www.youtube.com/playlist?list=PLP8iPy9hna6TJMLEiZZiWAXlyGtOyJSL7">JuliaCon Local Paris 2025 videos</a>
       </div>
     </div>


### PR DESCRIPTION
The 2025 videos button was pointing to the 2024 playlist. This fixes the link to point to the 2025 playlist as expected.