### PR TITLE
ci: declare contents:read on check_orgs workflow

### DIFF
--- a/.github/workflows/check_orgs.yml
+++ b/.github/workflows/check_orgs.yml
@@ -7,6 +7,9 @@ on:
   push:
     paths:
       - community/organizations.md
+permissions:
+  contents: read
+
 jobs:
   check_orgs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block to `.github/workflows/check_orgs.yml`. The job is a single-step Julia run that validates the publicly listed organizations file; nothing in the chain calls a GitHub API that needs write access.

Worth doing because of the runtime supply-chain threat surfaced by CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) - a tampered third-party action read `GITHUB_TOKEN` out of the workflow logs and the blast radius equalled the issued scope. Per-workflow caps bound that runtime authority irrespective of the repo or org default, give drift protection if the default ever widens, and is the only form OpenSSF Scorecard's Token-Permissions check credits. www.julialang.org is also the public face of the project so the in-file declaration makes the security posture self-documenting for casual readers.

Diff validated locally with `yaml.safe_load`.
