### PR TITLE
Manually update some JavaScript (pnpm) dependencies, to fix some Dependabot vulnerability alerts

### DIFF
--- a/visual-tests/package.json
+++ b/visual-tests/package.json
@@ -7,8 +7,8 @@
     "test:report": "npx playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.0",
-    "serve": "^14.2.0"
+    "@playwright/test": "^1.61.1",
+    "serve": "^14.2.6"
   },
   "packageManager": "pnpm@11.17.0",
   "pnpm": {

--- a/visual-tests/pnpm-lock.yaml
+++ b/visual-tests/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.50.0
+        specifier: ^1.61.1
         version: 1.61.1
       serve:
-        specifier: ^14.2.0
+        specifier: ^14.2.6
         version: 14.2.6(supports-color@7.2.0)
 
 packages:
@@ -60,8 +60,8 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -149,8 +149,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -367,7 +367,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -402,7 +402,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -492,7 +492,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fsevents@2.3.2:
     optional: true
@@ -535,7 +535,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 

--- a/visual-tests/pnpm-workspace.yaml
+++ b/visual-tests/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+minimumReleaseAgeExclude:
+  - brace-expansion@1.1.13 || 1.1.16
+  - fast-uri@3.1.3 || 3.1.4


### PR DESCRIPTION
Generated by running:

```bash
pnpm audit --fix=update
```