### PR TITLE
Add the winners of the 2026 Community Prizes

### DIFF
--- a/research.md
+++ b/research.md
@@ -10,6 +10,7 @@ Julia: A Fresh Approach to Numerical Computing. Jeff Bezanson, Alan Edelman, Ste
 
 Researchers contributing to Julia have been awarded various prizes:
 
+* [2026: Julia Community Prizes](https://juliacon.org/2026/prize/): Penelope Yong, Andreas Noack, Daniel Karrasch, and Jishnu Bhattacharya
 * [2025: Julia Community Prizes](https://juliacon.org/2025/prize/): Claire Foster and Stefan Krastanov
 * [2024: Julia Community Prizes](https://juliacon.org/2024/prize/): Guillaume Dalle, the Makie team (Simon Danisch, Julius Krumbiegel, Frederic Freyer, & Anshul Singhvi) and the JuMP team (Oscar Dowson, Benoît Legat, & Miles Lubin)
 * [2023: Julia Community Prizes](https://juliacon.org/2023/prize/): Valentin Churavy, William Moses, Ian Butterworth, Kristoffer Carlsson, and Yingbo Ma


### PR DESCRIPTION
Blocked by:
- [x] https://github.com/JuliaCon/www.juliacon.org/pull/841

https://github.com/JuliaCon/www.juliacon.org/pull/841 should be merged before this PR. Otherwise, the link will 404.