### PR TITLE
downloads: set upcoming release to v1.13.0-rc4

### DIFF
--- a/config.md
+++ b/config.md
@@ -29,7 +29,7 @@ hasmap = false
 
 # If the following lines are commented, the "upcoming release" section
 # in `downloads/index.md` will not be shown.
-upcoming_release = "1.13.0-rc3"
+upcoming_release = "1.13.0-rc4"
 upcoming_release_short = "1.13"
 upcoming_release_date = "2026"
 +++

--- a/downloads/oldreleases.md
+++ b/downloads/oldreleases.md
@@ -26,6 +26,120 @@ All releases and pre-releases are [tagged in git](https://github.com/JuliaLang/j
   <tbody>
 
   <tr>
+    <th scope="row" rowspan=14>v1.13.0-rc3, on 2026-08-14T06:07:42Z</th>
+
+    <td>Linux (glibc)</td>
+    <td>x86_64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/linux/x64/1.13/julia-1.13.0-rc3-linux-x86_64.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.13/julia-1.13.0-rc3-linux-x86_64.tar.gz.asc">asc</a>)</td>
+    <td>8d3f6366ad297d549afc51cf5c7cf2cc291d98467c602f22b91cd491867758f1</td>
+  </tr>
+
+  <tr>
+    <td>Linux (glibc)</td>
+    <td>i686</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/linux/x86/1.13/julia-1.13.0-rc3-linux-i686.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.13/julia-1.13.0-rc3-linux-i686.tar.gz.asc">asc</a>)</td>
+    <td>2d3f9c7cd2092555889720b162f8453696830d1b58c87b8883ec12bcb81bbefa</td>
+  </tr>
+
+  <tr>
+    <td>Linux (glibc)</td>
+    <td>aarch64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.13/julia-1.13.0-rc3-linux-aarch64.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/linux/aarch64/1.13/julia-1.13.0-rc3-linux-aarch64.tar.gz.asc">asc</a>)</td>
+    <td>76a16c597d51f7577fd1a57aa227592c7ba16c5a0b1c40c882d4189630eebb30</td>
+  </tr>
+
+  <tr>
+    <td>macOS</td>
+    <td>x86_64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/mac/x64/1.13/julia-1.13.0-rc3-mac64.dmg">dmg</a></td>
+    <td>198e046ade818a8b42672f0cd09d21775e4312a130269e294f210106fbad9136</td>
+  </tr>
+
+  <tr>
+    <td>macOS</td>
+    <td>aarch64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/mac/aarch64/1.13/julia-1.13.0-rc3-macaarch64.dmg">dmg</a></td>
+    <td>f5fa309b9df557322d25e8d348b264bf5a636accc6f9b26d0bd99f23c58dd4bf</td>
+  </tr>
+
+  <tr>
+    <td>macOS</td>
+    <td>x86_64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/mac/x64/1.13/julia-1.13.0-rc3-mac64.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/mac/x64/1.13/julia-1.13.0-rc3-mac64.tar.gz.asc">asc</a>)</td>
+    <td>a909022276e2eccb9d9c9629c2cd8be27dd3e72bb48ce4e860dd3e9899d89f3e</td>
+  </tr>
+
+  <tr>
+    <td>macOS</td>
+    <td>aarch64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/mac/aarch64/1.13/julia-1.13.0-rc3-macaarch64.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/mac/aarch64/1.13/julia-1.13.0-rc3-macaarch64.tar.gz.asc">asc</a>)</td>
+    <td>312eba41bb191b28ce4eece5d7166047071ecb3ead9685094033ddd570499c56</td>
+  </tr>
+
+  <tr>
+    <td>Windows</td>
+    <td>x86_64</td>
+    <td>installer</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.13/julia-1.13.0-rc3-win64.exe">exe</a></td>
+    <td>853b10c1e09988132d18fedf8a13388f8f814dc1aaff4123f37a7bea8ab29adb</td>
+  </tr>
+
+  <tr>
+    <td>Windows</td>
+    <td>i686</td>
+    <td>installer</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.13/julia-1.13.0-rc3-win32.exe">exe</a></td>
+    <td>b172dbb1cb25faffd3e4380766d5a8aebbd477140502f45619ec402e8d0c958b</td>
+  </tr>
+
+  <tr>
+    <td>Windows</td>
+    <td>x86_64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.13/julia-1.13.0-rc3-win64.zip">zip</a></td>
+    <td>29137ea1a87775cae29aa1b23bf4b932cb71bcbb663540582fed86e29327794e</td>
+  </tr>
+
+  <tr>
+    <td>Windows</td>
+    <td>i686</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.13/julia-1.13.0-rc3-win32.zip">zip</a></td>
+    <td>4ab969c6c8726629c879cb3a1c7af966494ca794958b332af280d2c648cc2a32</td>
+  </tr>
+
+  <tr>
+    <td>Windows</td>
+    <td>x86_64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.13/julia-1.13.0-rc3-win64.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.13/julia-1.13.0-rc3-win64.tar.gz.asc">asc</a>)</td>
+    <td>2e5338c3dbf8b3928e6e07cbefdeaf13c58f47f63bfca2e2211fd9f1be70963d</td>
+  </tr>
+
+  <tr>
+    <td>Windows</td>
+    <td>i686</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.13/julia-1.13.0-rc3-win32.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.13/julia-1.13.0-rc3-win32.tar.gz.asc">asc</a>)</td>
+    <td>562a54bd098919d6a44b6ede16876281ecb11ff5c8a7ccbbce141980f13b9873</td>
+  </tr>
+
+  <tr>
+    <td>FreeBSD</td>
+    <td>x86_64</td>
+    <td>archive</td>
+    <td><a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.13/julia-1.13.0-rc3-freebsd-x86_64.tar.gz">tar.gz</a> (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.13/julia-1.13.0-rc3-freebsd-x86_64.tar.gz.asc">asc</a>)</td>
+    <td>dc94af47be6267101ae79eb05596e4f3479bea15146e777a38b3da6eeb5354f7</td>
+  </tr>
+
+  <tr>
     <th scope="row" rowspan=14>v1.13.0-rc2, on 2026-08-13T09:43:38Z</th>
 
     <td>Linux (glibc)</td>


### PR DESCRIPTION
Bump the upcoming release on the downloads page to v1.13.0-rc4 and regenerate the old releases table with `downloads/oldreleases.jl`, which moves v1.13.0-rc3 there.

rc4 has been promoted to the release bucket (all CDN links the page builds from `config.md` resolve) and the GitHub release with the source dists is up at https://github.com/JuliaLang/julia/releases/tag/v1.13.0-rc4.

