### PR TITLE
blog: band alternate sections on every post

### DIFF
--- a/_css/app.css
+++ b/_css/app.css
@@ -657,6 +657,33 @@ h4 {
   margin-top: 1.25rem;
 }
 
+/* Blog posts: banded sections. /libs/blog-sections.js wraps each h2 (and the table of
+   contents) with its content in a <section class="blog-section">; alternate ones get a
+   faint full-bleed tint so the extent of each section is visible. The band is pulled
+   out to the viewport edges with negative margins and the content padded back into
+   the column, so the body must not scroll sideways on these pages. */
+body:has(.blog-title) {
+  overflow-x: hidden;
+}
+.blog-title ~ .container.main .blog-section {
+  padding: 0.25rem calc(50vw - 50%) 1rem;
+  margin: 1.5rem calc(50% - 50vw) 0;
+}
+.blog-title ~ .container.main .blog-section:nth-of-type(odd) {
+  padding-top: 0.75rem;
+  padding-bottom: 1.5rem;
+  background: rgba(74, 120, 214, 0.06);
+}
+[data-theme="dark"] .blog-title ~ .container.main .blog-section:nth-of-type(odd) {
+  background: rgba(255, 255, 255, 0.035);
+}
+.blog-title ~ .container.main .blog-section > h2:first-child {
+  margin-top: 0.75rem;
+}
+.blog-title ~ .container.main .blog-section > .franklin-toc {
+  margin-top: 0.5rem;
+}
+
 a {
   color: #005bc0;
 }

--- a/_layout/foot.html
+++ b/_layout/foot.html
@@ -11,6 +11,9 @@
     {{insert foot_clipboard.html}}
 
     {{insert foot_general.html}}
+    {{ispage /blog/*}}{{isnotpage /blog/index.html}}
+    <script src="/libs/blog-sections.js"></script>
+    {{end}}{{end}}
     {{if hasmap}}
     <script src="/libs/groups.js"></script>
     <script src="/libs/map.js"></script>

--- a/_libs/blog-sections.js
+++ b/_libs/blog-sections.js
@@ -1,0 +1,16 @@
+// Group each h2 in a blog post with the content that follows it, so alternate
+// sections can be tinted (see "Blog posts: banded sections" in _css/app.css).
+// The table of contents, when present, is the first band.
+(function () {
+  var main = document.querySelector(".blog-title ~ .container.main");
+  if (!main) return;
+  var sec = null;
+  Array.prototype.slice.call(main.childNodes).forEach(function (n) {
+    if (n.nodeType === 1 && (n.tagName === "H2" || n.classList.contains("franklin-toc"))) {
+      sec = document.createElement("section");
+      sec.className = "blog-section";
+      main.insertBefore(sec, n);
+    }
+    if (sec) sec.appendChild(n);
+  });
+})();

--- a/blog/2026/09/julia-1.13-highlights.md
+++ b/blog/2026/09/julia-1.13-highlights.md
@@ -50,15 +50,6 @@ The chart below shows the geometric mean across all 39 currently submitted workf
 .ttfx-narrow .ttfx-axis-label { font-size: 15px; }
 .ttfx-narrow .ttfx-delta { font-size: 12.5px; }
 .center-table table { margin-left: auto; margin-right: auto; }
-/* Alternate a faint tint behind every other major section so their extent is visible. */
-/* Full-bleed: pull the band out to the viewport edges and pad the content back into the column. */
-.hl-section { padding: 0.25rem calc(50vw - 50%) 1rem; margin: 1.5rem calc(50% - 50vw) 0; }
-.hl-section:nth-of-type(odd) { padding-top: 0.75rem; padding-bottom: 1.5rem; }
-.hl-section > .franklin-toc { margin-top: 0.5rem; }
-body { overflow-x: hidden; }
-.hl-section:nth-of-type(odd) { background: rgba(74, 120, 214, 0.06); }
-[data-theme="dark"] .hl-section:nth-of-type(odd) { background: rgba(255, 255, 255, 0.035); }
-.blog-title ~ .container.main .hl-section > h2:first-child { margin-top: 0.75rem; }
 .ttfx-ink { fill: #0b0b0b; } .ttfx-ink2 { fill: #52514e; } .ttfx-muted { fill: #898781; }
 .ttfx-grid { stroke: #e1e0d9; } .ttfx-axis { stroke: #c3c2b7; }
 .ttfx-ring { stroke: #fff; stroke-width: 2; }
@@ -451,24 +442,4 @@ The **Available** tab lists everything in the channel database, including `relea
 
 ~~~
 <p style="text-align: center"><img src="/assets/blog/2026-1.13-highlights/juliaup-gui-available.png" alt="The Juliaup GUI's Available tab, listing channels that can be installed" width="900" style="max-width: 100%"></p>
-~~~
-
-~~~
-<script>
-// Group each h2 with the content that follows it, so the sections can be tinted.
-(function () {
-  var main = document.querySelector(".container.main");
-  if (!main) return;
-  var sec = null;
-  Array.prototype.slice.call(main.childNodes).forEach(function (n) {
-    // The table of contents is the first band; each h2 then starts a new one.
-    if (n.nodeType === 1 && (n.tagName === "H2" || n.classList.contains("franklin-toc"))) {
-      sec = document.createElement("section");
-      sec.className = "hl-section";
-      main.insertBefore(sec, n);
-    }
-    if (sec) sec.appendChild(n);
-  });
-})();
-</script>
 ~~~


### PR DESCRIPTION
I looked around and this generally seemed to look ok on old posts. Better on ones that use H2 tags.

Claude:

---

The 1.13 highlights post (#2578) shipped with a faint full-bleed tint behind every other major section, so each section's extent is visible at a glance. That was implemented inside the one post, as inline CSS and a script at the end of the file.

This moves it site-wide. The script that wraps each `h2` (and the table of contents, when present) with its content now lives in `_libs/blog-sections.js` and is loaded from the blog footer, on posts only. The styles move into `app.css`, scoped to blog pages the same way as the heading spacing rules. The sideways-scroll guard that the full-bleed band needs is scoped with `body:has(.blog-title)` rather than applied to every page. The highlights post loses its private copies and is otherwise unchanged.

Posts without `h2` headings, such as the monthly roundups, get no bands and render as before. Checked locally on the 1.13 and 1.12 highlights posts and on a non-blog page.
